### PR TITLE
newtonpf.py: choose solver based on distributed_slack parameter

### DIFF
--- a/lightsim2grid/newtonpf/newtonpf.py
+++ b/lightsim2grid/newtonpf/newtonpf.py
@@ -10,15 +10,16 @@ import warnings
 import numpy as np
 from scipy import sparse
 
-from lightsim2grid_cpp import SparseLUSolver
-KLU_solver_available = False
+from lightsim2grid_cpp import SparseLUSolver, SparseLUSolverSingleSlack
+
 try:
-    from lightsim2grid_cpp import KLUSolver
+    from lightsim2grid_cpp import KLUSolver, KLUSolverSingleSlack
     KLU_solver_available = True
 except ImportError:
-    pass
+    KLU_solver_available = False
 
 _PP_VERSION_MAX = "2.7.0"
+
 
 def _isolate_slack_ids(Sbus, pv, pq):
     # extract the slack bus
@@ -290,14 +291,14 @@ def newtonpf_new(Ybus, Sbus, V0, ref, pv, pq, ppci, options):
         By default (and this cannot be changed at the moment), all buses in `ref` will be pv buses except the first one.
 
     """
-    max_it = options["max_iteration"]
-    tol = options['tolerance_mva']
-    bus = ppci['bus']
+    max_iteration = options["max_iteration"]
+    tolerance_pu = options['tolerance_mva']  # / ppci["baseMVA"]
 
     try:
-        from pandapower.pypower.idx_bus import SL_FAC  # lazy import for earlier pandapower version (without distributed slack)
-        slack_weights = bus[:, SL_FAC].astype(float)  ## contribution factors for distributed slack
-        slack_weights /= slack_weights.sum()
+        # lazy import for earlier pandapower version (without distributed slack):
+        from pandapower.pypower.idx_bus import SL_FAC
+        # contribution factors for distributed slack:
+        slack_weights = ppci['bus'][:, SL_FAC].astype(np.float64)
     except ImportError:
         # earlier version of pandapower
         warnings.warn("You are using a pandapower version that does not support distributed slack. We will attempt to "
@@ -306,14 +307,16 @@ def newtonpf_new(Ybus, Sbus, V0, ref, pv, pq, ppci, options):
 
     # initialize the solver
     # TODO have that in options maybe (can use GaussSeidel, and NR with KLU -faster- or SparseLU)
-    if KLU_solver_available:
-        solver = KLUSolver()
+    if options["distributed_slack"]:
+        solver = KLUSolver() if KLU_solver_available else SparseLUSolver()
     else:
-        solver = SparseLUSolver()
-    Ybus = sparse.csc_matrix(Ybus)
+        solver = KLUSolverSingleSlack() if KLU_solver_available else SparseLUSolverSingleSlack()
+
+    if ~sparse.isspmatrix_csc(Ybus):
+        Ybus = sparse.csc_matrix(Ybus)
 
     # do the newton raphson algorithm
-    solver.solve(Ybus, V0, Sbus, ref, slack_weights, pv, pq, max_it, tol)
+    solver.solve(Ybus, V0, Sbus, ref, slack_weights, pv, pq, max_iteration, tolerance_pu)
 
     # extract the results
     Va = solver.get_Va()


### PR DESCRIPTION
+Some small changes

* to make the behavior in lightsim2grid and pandapower consistent in terms of the J matrix, we choose the "standard" vs "single slack" version of the solver bnased on the parameter "distributed_slack".
* We transform the Ybus to csc if it is not yet csc. TODO for pandapower: define Ybus in csc in the first place if lightsim2grid is used (right now implemented via to_csc()).