### PR TITLE
Upgrade to version 0.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ benchmarks/case3120sp.json
 benchmarks/case6495rte.json
 _pandapower
 benchmarks/slacks.py
+_gridcal

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ benchmarks/case6495rte.json
 _pandapower
 benchmarks/slacks.py
 _gridcal
+*grid.json

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ bug_pandapower.py
 bug_pp.py
 old_pyproject.toml
 test_gridcal.py
+lightsim2grid/tests/bug_file.zip
+lightsim2grid/tests/test.json
+pyproject.toml.old

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,7 @@ _pandapower
 benchmarks/slacks.py
 _gridcal
 *grid.json
+bug_pandapower.py
+bug_pp.py
+old_pyproject.toml
+test_gridcal.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,15 @@ Change Log
 - easier building (get rid of the "make" part)
 - code NR with dense matrices
 
+[0.6.1] 2022-02-01
+--------------------
+- [BREAKING] the behaviour of the `newton_pf` function is not 
+  consistent with pandapower default concerning distributed slack.
+- [FIXED] an issue in the distributed slack case spotted by pandapower team 
+  thanks to them (see https://github.com/e2nIEE/pandapower/pull/1455)
+- [IMPROVED] lightsim2grid will now use the single slack algorithm if the 
+  grids counts only one slack bus (performance increase)
+
 [0.6.0] 2021-12-17
 -------------------
 - [BREAKING] change the interface of the `newton_pf` function to reflect pandapower change in their

--- a/benchmarks/grid_size.py
+++ b/benchmarks/grid_size.py
@@ -16,6 +16,7 @@ from grid2op import make, Parameters
 from grid2op.Chronics import ChangeNothing
 from lightsim2grid import LightSimBackend, TimeSerie
 from tqdm import tqdm
+import os
 
 VERBOSE = False
 
@@ -29,14 +30,17 @@ case_names = ["case118.json",
               "case2869pegase.json",
               "case3120sp.json",
               "case6495rte.json",
-              "case9241pegase.json"]
+              "case9241pegase.json"
+              ]
 
 def make_grid2op_env(pp_case, casse_name):
     param = Parameters.Parameters()
     param.init_from_dict({"NO_OVERFLOW_DISCONNECTION": True})
+        
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")
-        env_lightsim = make("blank", param=param, test=True,
+        env_lightsim = make("blank",
+                            param=param, test=True,
                             backend=LightSimBackend(),
                             data_feeding_kwargs={"gridvalueClass": ChangeNothing},
                             grid_path=case_name,
@@ -134,6 +138,12 @@ if __name__ == "__main__":
     speeds = []
     sizes = []
     for case_name in tqdm(case_names):
+
+        if not os.path.exists(case_name):
+            import pandapower.networks as pn
+            case = getattr(pn, os.path.splitext(case_name)[0])()
+            pp.to_json(case, case_name)
+
         # load the case file
         case = pp.from_json(case_name)
         # extract reference data
@@ -203,4 +213,5 @@ if __name__ == "__main__":
     plt.xlabel("Size (number of substation)")
     plt.ylabel("Speed (pf / s)")
     plt.title(f"Computation speed")
+    plt.yscale("log")
     plt.show()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin DONNOT'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.0'
+release = '0.6.1'
 version = '0.6'
 
 # -- General configuration ---------------------------------------------------

--- a/lightsim2grid/__init__.py
+++ b/lightsim2grid/__init__.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = ["newtonpf", "SolverType", "ErrorType", "solver"]
 

--- a/lightsim2grid/gridmodel/_aux_add_slack.py
+++ b/lightsim2grid/gridmodel/_aux_add_slack.py
@@ -41,10 +41,11 @@ def _aux_add_slack(model, pp_net):
         for slack_id in slack_gen_ids:
             model.change_v_gen(slack_id, pp_net.gen["vm_pu"].iloc[slack_id])
 
-        has_nan = np.any(~np.isfinite(slack_coeff))
-        if has_nan:
-            warnings.warn("Some slack coefficients were Nans. We set them all to 1.0")
-            slack_coeff[:] = 1.0
+        if slack_coeff is not None:
+            has_nan = np.any(~np.isfinite(slack_coeff))
+            if has_nan:
+                warnings.warn("Some slack coefficients were Nans. We set them all to 1.0")
+                slack_coeff[:] = 1.0
             
         # in this case the ext grid is not taken into account, i raise a warning if
         # there is one

--- a/lightsim2grid/gridmodel/_aux_add_trafo.py
+++ b/lightsim2grid/gridmodel/_aux_add_trafo.py
@@ -61,7 +61,7 @@ def _aux_add_trafo(converter, model, pp_net):
                            "pp_net.trafo[\"tap_phase_shifter\"] set to True.")
 
     tap_angles_ = 1.0 * pp_net.trafo["tap_step_degree"].values
-    if np.any(~np.isfinite(tap_pos)):
+    if np.any(~np.isfinite(tap_angles_)):
         warnings.warn("There were some Nan in the pp_net.trafo[\"tap_step_degree\"], they have been replaced by 0")
     tap_angles_[~np.isfinite(tap_angles_)] = 0.
     tap_angles_ = np.deg2rad(tap_angles_)

--- a/lightsim2grid/newtonpf/newtonpf.py
+++ b/lightsim2grid/newtonpf/newtonpf.py
@@ -303,7 +303,7 @@ def newtonpf_new(Ybus, Sbus, V0, ref, pv, pq, ppci, options):
         warnings.warn("You are using a pandapower version that does not support distributed slack. We will attempt to "
                       "replicate this with lightsim2grid.")
         ref, slack_weights = _isolate_slack_ids(Sbus, pv, pq)
-
+    
     # initialize the solver
     # TODO have that in options maybe (can use GaussSeidel, and NR with KLU -faster- or SparseLU)
     if KLU_solver_available:

--- a/lightsim2grid/tests/dist_slack_test.json
+++ b/lightsim2grid/tests/dist_slack_test.json
@@ -1,0 +1,1773 @@
+{
+  "_module": "pandapower.auxiliary",
+  "_class": "pandapowerNet",
+  "_object": {
+    "bus": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"vn_kv\",\"type\",\"zone\",\"in_service\"],\"index\":[0,1,2],\"data\":[[null,20.0,\"b\",null,true],[null,20.0,\"b\",null,true],[null,20.0,\"b\",null,true]]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "vn_kv": "float64",
+        "type": "object",
+        "zone": "object",
+        "in_service": "bool"
+      }
+    },
+    "load": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_mw\",\"q_mvar\",\"const_z_percent\",\"const_i_percent\",\"sn_mva\",\"scaling\",\"in_service\",\"type\"],\"index\":[0],\"data\":[[null,1,100.0,100.0,0.0,0.0,null,1.0,true,\"wye\"]]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "const_z_percent": "float64",
+        "const_i_percent": "float64",
+        "sn_mva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+      }
+    },
+    "sgen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_mw\",\"q_mvar\",\"sn_mva\",\"scaling\",\"in_service\",\"type\",\"current_source\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "sn_mva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object",
+        "current_source": "bool"
+      }
+    },
+    "motor": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"pn_mech_mw\",\"loading_percent\",\"cos_phi\",\"cos_phi_n\",\"efficiency_percent\",\"efficiency_n_percent\",\"lrc_pu\",\"vn_kv\",\"scaling\",\"in_service\",\"rx\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "pn_mech_mw": "float64",
+        "loading_percent": "float64",
+        "cos_phi": "float64",
+        "cos_phi_n": "float64",
+        "efficiency_percent": "float64",
+        "efficiency_n_percent": "float64",
+        "lrc_pu": "float64",
+        "vn_kv": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "rx": "float64"
+      }
+    },
+    "asymmetric_load": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\",\"sn_mva\",\"scaling\",\"in_service\",\"type\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64",
+        "sn_mva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+      }
+    },
+    "asymmetric_sgen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\",\"sn_mva\",\"scaling\",\"in_service\",\"type\",\"current_source\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64",
+        "sn_mva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object",
+        "current_source": "bool"
+      }
+    },
+    "storage": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_mw\",\"q_mvar\",\"sn_mva\",\"soc_percent\",\"min_e_mwh\",\"max_e_mwh\",\"scaling\",\"in_service\",\"type\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "sn_mva": "float64",
+        "soc_percent": "float64",
+        "min_e_mwh": "float64",
+        "max_e_mwh": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+      }
+    },
+    "gen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"p_mw\",\"vm_pu\",\"sn_mva\",\"min_q_mvar\",\"max_q_mvar\",\"scaling\",\"slack\",\"in_service\",\"slack_weight\",\"type\",\"power_station_trafo\"],\"index\":[0,1],\"data\":[[null,0,100.0,1.0,null,null,null,1.0,true,true,1.0,null,null],[null,2,200.0,1.0,null,null,null,1.0,false,true,2.0,null,null]]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "p_mw": "float64",
+        "vm_pu": "float64",
+        "sn_mva": "float64",
+        "min_q_mvar": "float64",
+        "max_q_mvar": "float64",
+        "scaling": "float64",
+        "slack": "bool",
+        "in_service": "bool",
+        "slack_weight": "float64",
+        "type": "object",
+        "power_station_trafo": "float64"
+      }
+    },
+    "switch": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"bus\",\"element\",\"et\",\"type\",\"closed\",\"name\",\"z_ohm\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "bus": "int64",
+        "element": "int64",
+        "et": "object",
+        "type": "object",
+        "closed": "bool",
+        "name": "object",
+        "z_ohm": "float64"
+      }
+    },
+    "shunt": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"bus\",\"name\",\"q_mvar\",\"p_mw\",\"vn_kv\",\"step\",\"max_step\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "bus": "uint32",
+        "name": "object",
+        "q_mvar": "float64",
+        "p_mw": "float64",
+        "vn_kv": "float64",
+        "step": "uint32",
+        "max_step": "uint32",
+        "in_service": "bool"
+      }
+    },
+    "ext_grid": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"vm_pu\",\"va_degree\",\"slack_weight\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "vm_pu": "float64",
+        "va_degree": "float64",
+        "slack_weight": "float64",
+        "in_service": "bool"
+      }
+    },
+    "line": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"std_type\",\"from_bus\",\"to_bus\",\"length_km\",\"r_ohm_per_km\",\"x_ohm_per_km\",\"c_nf_per_km\",\"g_us_per_km\",\"max_i_ka\",\"df\",\"parallel\",\"type\",\"in_service\"],\"index\":[0,1,2],\"data\":[[null,null,0,1,3.0,0.01,0.1,0.0,0.0,1.0,1.0,1,null,true],[null,null,1,2,2.0,0.01,0.1,0.0,0.0,1.0,1.0,1,null,true],[null,null,2,0,1.0,0.01,0.1,0.0,0.0,1.0,1.0,1,null,true]]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "length_km": "float64",
+        "r_ohm_per_km": "float64",
+        "x_ohm_per_km": "float64",
+        "c_nf_per_km": "float64",
+        "g_us_per_km": "float64",
+        "max_i_ka": "float64",
+        "df": "float64",
+        "parallel": "uint32",
+        "type": "object",
+        "in_service": "bool"
+      }
+    },
+    "trafo": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"std_type\",\"hv_bus\",\"lv_bus\",\"sn_mva\",\"vn_hv_kv\",\"vn_lv_kv\",\"vk_percent\",\"vkr_percent\",\"pfe_kw\",\"i0_percent\",\"shift_degree\",\"tap_side\",\"tap_neutral\",\"tap_min\",\"tap_max\",\"tap_step_percent\",\"tap_step_degree\",\"tap_pos\",\"tap_phase_shifter\",\"parallel\",\"df\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "hv_bus": "uint32",
+        "lv_bus": "uint32",
+        "sn_mva": "float64",
+        "vn_hv_kv": "float64",
+        "vn_lv_kv": "float64",
+        "vk_percent": "float64",
+        "vkr_percent": "float64",
+        "pfe_kw": "float64",
+        "i0_percent": "float64",
+        "shift_degree": "float64",
+        "tap_side": "object",
+        "tap_neutral": "int32",
+        "tap_min": "int32",
+        "tap_max": "int32",
+        "tap_step_percent": "float64",
+        "tap_step_degree": "float64",
+        "tap_pos": "int32",
+        "tap_phase_shifter": "bool",
+        "parallel": "uint32",
+        "df": "float64",
+        "in_service": "bool"
+      }
+    },
+    "trafo3w": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"std_type\",\"hv_bus\",\"mv_bus\",\"lv_bus\",\"sn_hv_mva\",\"sn_mv_mva\",\"sn_lv_mva\",\"vn_hv_kv\",\"vn_mv_kv\",\"vn_lv_kv\",\"vk_hv_percent\",\"vk_mv_percent\",\"vk_lv_percent\",\"vkr_hv_percent\",\"vkr_mv_percent\",\"vkr_lv_percent\",\"pfe_kw\",\"i0_percent\",\"shift_mv_degree\",\"shift_lv_degree\",\"tap_side\",\"tap_neutral\",\"tap_min\",\"tap_max\",\"tap_step_percent\",\"tap_step_degree\",\"tap_pos\",\"tap_at_star_point\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "hv_bus": "uint32",
+        "mv_bus": "uint32",
+        "lv_bus": "uint32",
+        "sn_hv_mva": "float64",
+        "sn_mv_mva": "float64",
+        "sn_lv_mva": "float64",
+        "vn_hv_kv": "float64",
+        "vn_mv_kv": "float64",
+        "vn_lv_kv": "float64",
+        "vk_hv_percent": "float64",
+        "vk_mv_percent": "float64",
+        "vk_lv_percent": "float64",
+        "vkr_hv_percent": "float64",
+        "vkr_mv_percent": "float64",
+        "vkr_lv_percent": "float64",
+        "pfe_kw": "float64",
+        "i0_percent": "float64",
+        "shift_mv_degree": "float64",
+        "shift_lv_degree": "float64",
+        "tap_side": "object",
+        "tap_neutral": "int32",
+        "tap_min": "int32",
+        "tap_max": "int32",
+        "tap_step_percent": "float64",
+        "tap_step_degree": "float64",
+        "tap_pos": "int32",
+        "tap_at_star_point": "bool",
+        "in_service": "bool"
+      }
+    },
+    "impedance": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"from_bus\",\"to_bus\",\"rft_pu\",\"xft_pu\",\"rtf_pu\",\"xtf_pu\",\"sn_mva\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "rft_pu": "float64",
+        "xft_pu": "float64",
+        "rtf_pu": "float64",
+        "xtf_pu": "float64",
+        "sn_mva": "float64",
+        "in_service": "bool"
+      }
+    },
+    "dcline": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"from_bus\",\"to_bus\",\"p_mw\",\"loss_percent\",\"loss_mw\",\"vm_from_pu\",\"vm_to_pu\",\"max_p_mw\",\"min_q_from_mvar\",\"min_q_to_mvar\",\"max_q_from_mvar\",\"max_q_to_mvar\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "p_mw": "float64",
+        "loss_percent": "float64",
+        "loss_mw": "float64",
+        "vm_from_pu": "float64",
+        "vm_to_pu": "float64",
+        "max_p_mw": "float64",
+        "min_q_from_mvar": "float64",
+        "min_q_to_mvar": "float64",
+        "max_q_from_mvar": "float64",
+        "max_q_to_mvar": "float64",
+        "in_service": "bool"
+      }
+    },
+    "ward": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"ps_mw\",\"qs_mvar\",\"qz_mvar\",\"pz_mw\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "ps_mw": "float64",
+        "qs_mvar": "float64",
+        "qz_mvar": "float64",
+        "pz_mw": "float64",
+        "in_service": "bool"
+      }
+    },
+    "xward": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"bus\",\"ps_mw\",\"qs_mvar\",\"qz_mvar\",\"pz_mw\",\"r_ohm\",\"x_ohm\",\"vm_pu\",\"slack_weight\",\"in_service\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "ps_mw": "float64",
+        "qs_mvar": "float64",
+        "qz_mvar": "float64",
+        "pz_mw": "float64",
+        "r_ohm": "float64",
+        "x_ohm": "float64",
+        "vm_pu": "float64",
+        "slack_weight": "float64",
+        "in_service": "bool"
+      }
+    },
+    "measurement": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"name\",\"measurement_type\",\"element_type\",\"element\",\"value\",\"std_dev\",\"side\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "name": "object",
+        "measurement_type": "object",
+        "element_type": "object",
+        "element": "uint32",
+        "value": "float64",
+        "std_dev": "float64",
+        "side": "object"
+      }
+    },
+    "pwl_cost": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"power_type\",\"element\",\"et\",\"points\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "power_type": "object",
+        "element": "uint32",
+        "et": "object",
+        "points": "object"
+      }
+    },
+    "poly_cost": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"element\",\"et\",\"cp0_eur\",\"cp1_eur_per_mw\",\"cp2_eur_per_mw2\",\"cq0_eur\",\"cq1_eur_per_mvar\",\"cq2_eur_per_mvar2\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "element": "uint32",
+        "et": "object",
+        "cp0_eur": "float64",
+        "cp1_eur_per_mw": "float64",
+        "cp2_eur_per_mw2": "float64",
+        "cq0_eur": "float64",
+        "cq1_eur_per_mvar": "float64",
+        "cq2_eur_per_mvar2": "float64"
+      }
+    },
+    "characteristic": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"object\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "object": "object"
+      }
+    },
+    "controller": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"object\",\"in_service\",\"order\",\"level\",\"initial_run\",\"recycle\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "object": "object",
+        "in_service": "bool",
+        "order": "float64",
+        "level": "object",
+        "initial_run": "bool",
+        "recycle": "object"
+      }
+    },
+    "line_geodata": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"coords\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "coords": "object"
+      }
+    },
+    "bus_geodata": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"x\",\"y\",\"coords\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "x": "float64",
+        "y": "float64",
+        "coords": "object"
+      }
+    },
+    "version": "2.7.1.dev1",
+    "converged": true,
+    "name": "",
+    "f_hz": 50.0,
+    "sn_mva": 1,
+    "std_types": {
+      "line": {
+        "NAYY 4x50 SE": {
+          "c_nf_per_km": 210,
+          "r_ohm_per_km": 0.642,
+          "x_ohm_per_km": 0.083,
+          "max_i_ka": 0.142,
+          "type": "cs",
+          "q_mm2": 50,
+          "alpha": 0.00403
+        },
+        "NAYY 4x120 SE": {
+          "c_nf_per_km": 264,
+          "r_ohm_per_km": 0.225,
+          "x_ohm_per_km": 0.08,
+          "max_i_ka": 0.242,
+          "type": "cs",
+          "q_mm2": 120,
+          "alpha": 0.00403
+        },
+        "NAYY 4x150 SE": {
+          "c_nf_per_km": 261,
+          "r_ohm_per_km": 0.208,
+          "x_ohm_per_km": 0.08,
+          "max_i_ka": 0.27,
+          "type": "cs",
+          "q_mm2": 150,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x95 RM/25 12/20 kV": {
+          "c_nf_per_km": 216,
+          "r_ohm_per_km": 0.313,
+          "x_ohm_per_km": 0.132,
+          "max_i_ka": 0.252,
+          "type": "cs",
+          "q_mm2": 95,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x185 RM/25 12/20 kV": {
+          "c_nf_per_km": 273,
+          "r_ohm_per_km": 0.161,
+          "x_ohm_per_km": 0.117,
+          "max_i_ka": 0.362,
+          "type": "cs",
+          "q_mm2": 185,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x240 RM/25 12/20 kV": {
+          "c_nf_per_km": 304,
+          "r_ohm_per_km": 0.122,
+          "x_ohm_per_km": 0.112,
+          "max_i_ka": 0.421,
+          "type": "cs",
+          "q_mm2": 240,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x95 RM/25 6/10 kV": {
+          "c_nf_per_km": 315,
+          "r_ohm_per_km": 0.313,
+          "x_ohm_per_km": 0.123,
+          "max_i_ka": 0.249,
+          "type": "cs",
+          "q_mm2": 95,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x185 RM/25 6/10 kV": {
+          "c_nf_per_km": 406,
+          "r_ohm_per_km": 0.161,
+          "x_ohm_per_km": 0.11,
+          "max_i_ka": 0.358,
+          "type": "cs",
+          "q_mm2": 185,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x240 RM/25 6/10 kV": {
+          "c_nf_per_km": 456,
+          "r_ohm_per_km": 0.122,
+          "x_ohm_per_km": 0.105,
+          "max_i_ka": 0.416,
+          "type": "cs",
+          "q_mm2": 240,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x150 RM/25 12/20 kV": {
+          "c_nf_per_km": 250,
+          "r_ohm_per_km": 0.206,
+          "x_ohm_per_km": 0.116,
+          "max_i_ka": 0.319,
+          "type": "cs",
+          "q_mm2": 150,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x120 RM/25 12/20 kV": {
+          "c_nf_per_km": 230,
+          "r_ohm_per_km": 0.253,
+          "x_ohm_per_km": 0.119,
+          "max_i_ka": 0.283,
+          "type": "cs",
+          "q_mm2": 120,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x70 RM/25 12/20 kV": {
+          "c_nf_per_km": 190,
+          "r_ohm_per_km": 0.443,
+          "x_ohm_per_km": 0.132,
+          "max_i_ka": 0.22,
+          "type": "cs",
+          "q_mm2": 70,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x150 RM/25 6/10 kV": {
+          "c_nf_per_km": 360,
+          "r_ohm_per_km": 0.206,
+          "x_ohm_per_km": 0.11,
+          "max_i_ka": 0.315,
+          "type": "cs",
+          "q_mm2": 150,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x120 RM/25 6/10 kV": {
+          "c_nf_per_km": 340,
+          "r_ohm_per_km": 0.253,
+          "x_ohm_per_km": 0.113,
+          "max_i_ka": 0.28,
+          "type": "cs",
+          "q_mm2": 120,
+          "alpha": 0.00403
+        },
+        "NA2XS2Y 1x70 RM/25 6/10 kV": {
+          "c_nf_per_km": 280,
+          "r_ohm_per_km": 0.443,
+          "x_ohm_per_km": 0.123,
+          "max_i_ka": 0.217,
+          "type": "cs",
+          "q_mm2": 70,
+          "alpha": 0.00403
+        },
+        "N2XS(FL)2Y 1x120 RM/35 64/110 kV": {
+          "c_nf_per_km": 112,
+          "r_ohm_per_km": 0.153,
+          "x_ohm_per_km": 0.166,
+          "max_i_ka": 0.366,
+          "type": "cs",
+          "q_mm2": 120,
+          "alpha": 0.00393
+        },
+        "N2XS(FL)2Y 1x185 RM/35 64/110 kV": {
+          "c_nf_per_km": 125,
+          "r_ohm_per_km": 0.099,
+          "x_ohm_per_km": 0.156,
+          "max_i_ka": 0.457,
+          "type": "cs",
+          "q_mm2": 185,
+          "alpha": 0.00393
+        },
+        "N2XS(FL)2Y 1x240 RM/35 64/110 kV": {
+          "c_nf_per_km": 135,
+          "r_ohm_per_km": 0.075,
+          "x_ohm_per_km": 0.149,
+          "max_i_ka": 0.526,
+          "type": "cs",
+          "q_mm2": 240,
+          "alpha": 0.00393
+        },
+        "N2XS(FL)2Y 1x300 RM/35 64/110 kV": {
+          "c_nf_per_km": 144,
+          "r_ohm_per_km": 0.06,
+          "x_ohm_per_km": 0.144,
+          "max_i_ka": 0.588,
+          "type": "cs",
+          "q_mm2": 300,
+          "alpha": 0.00393
+        },
+        "15-AL1/3-ST1A 0.4": {
+          "c_nf_per_km": 11,
+          "r_ohm_per_km": 1.8769,
+          "x_ohm_per_km": 0.35,
+          "max_i_ka": 0.105,
+          "type": "ol",
+          "q_mm2": 16,
+          "alpha": 0.00403
+        },
+        "24-AL1/4-ST1A 0.4": {
+          "c_nf_per_km": 11.25,
+          "r_ohm_per_km": 1.2012,
+          "x_ohm_per_km": 0.335,
+          "max_i_ka": 0.14,
+          "type": "ol",
+          "q_mm2": 24,
+          "alpha": 0.00403
+        },
+        "48-AL1/8-ST1A 0.4": {
+          "c_nf_per_km": 12.2,
+          "r_ohm_per_km": 0.5939,
+          "x_ohm_per_km": 0.3,
+          "max_i_ka": 0.21,
+          "type": "ol",
+          "q_mm2": 48,
+          "alpha": 0.00403
+        },
+        "94-AL1/15-ST1A 0.4": {
+          "c_nf_per_km": 13.2,
+          "r_ohm_per_km": 0.306,
+          "x_ohm_per_km": 0.29,
+          "max_i_ka": 0.35,
+          "type": "ol",
+          "q_mm2": 94,
+          "alpha": 0.00403
+        },
+        "34-AL1/6-ST1A 10.0": {
+          "c_nf_per_km": 9.7,
+          "r_ohm_per_km": 0.8342,
+          "x_ohm_per_km": 0.36,
+          "max_i_ka": 0.17,
+          "type": "ol",
+          "q_mm2": 34,
+          "alpha": 0.00403
+        },
+        "48-AL1/8-ST1A 10.0": {
+          "c_nf_per_km": 10.1,
+          "r_ohm_per_km": 0.5939,
+          "x_ohm_per_km": 0.35,
+          "max_i_ka": 0.21,
+          "type": "ol",
+          "q_mm2": 48,
+          "alpha": 0.00403
+        },
+        "70-AL1/11-ST1A 10.0": {
+          "c_nf_per_km": 10.4,
+          "r_ohm_per_km": 0.4132,
+          "x_ohm_per_km": 0.339,
+          "max_i_ka": 0.29,
+          "type": "ol",
+          "q_mm2": 70,
+          "alpha": 0.00403
+        },
+        "94-AL1/15-ST1A 10.0": {
+          "c_nf_per_km": 10.75,
+          "r_ohm_per_km": 0.306,
+          "x_ohm_per_km": 0.33,
+          "max_i_ka": 0.35,
+          "type": "ol",
+          "q_mm2": 94,
+          "alpha": 0.00403
+        },
+        "122-AL1/20-ST1A 10.0": {
+          "c_nf_per_km": 11.1,
+          "r_ohm_per_km": 0.2376,
+          "x_ohm_per_km": 0.323,
+          "max_i_ka": 0.41,
+          "type": "ol",
+          "q_mm2": 122,
+          "alpha": 0.00403
+        },
+        "149-AL1/24-ST1A 10.0": {
+          "c_nf_per_km": 11.25,
+          "r_ohm_per_km": 0.194,
+          "x_ohm_per_km": 0.315,
+          "max_i_ka": 0.47,
+          "type": "ol",
+          "q_mm2": 149,
+          "alpha": 0.00403
+        },
+        "34-AL1/6-ST1A 20.0": {
+          "c_nf_per_km": 9.15,
+          "r_ohm_per_km": 0.8342,
+          "x_ohm_per_km": 0.382,
+          "max_i_ka": 0.17,
+          "type": "ol",
+          "q_mm2": 34,
+          "alpha": 0.00403
+        },
+        "48-AL1/8-ST1A 20.0": {
+          "c_nf_per_km": 9.5,
+          "r_ohm_per_km": 0.5939,
+          "x_ohm_per_km": 0.372,
+          "max_i_ka": 0.21,
+          "type": "ol",
+          "q_mm2": 48,
+          "alpha": 0.00403
+        },
+        "70-AL1/11-ST1A 20.0": {
+          "c_nf_per_km": 9.7,
+          "r_ohm_per_km": 0.4132,
+          "x_ohm_per_km": 0.36,
+          "max_i_ka": 0.29,
+          "type": "ol",
+          "q_mm2": 70,
+          "alpha": 0.00403
+        },
+        "94-AL1/15-ST1A 20.0": {
+          "c_nf_per_km": 10,
+          "r_ohm_per_km": 0.306,
+          "x_ohm_per_km": 0.35,
+          "max_i_ka": 0.35,
+          "type": "ol",
+          "q_mm2": 94,
+          "alpha": 0.00403
+        },
+        "122-AL1/20-ST1A 20.0": {
+          "c_nf_per_km": 10.3,
+          "r_ohm_per_km": 0.2376,
+          "x_ohm_per_km": 0.344,
+          "max_i_ka": 0.41,
+          "type": "ol",
+          "q_mm2": 122,
+          "alpha": 0.00403
+        },
+        "149-AL1/24-ST1A 20.0": {
+          "c_nf_per_km": 10.5,
+          "r_ohm_per_km": 0.194,
+          "x_ohm_per_km": 0.337,
+          "max_i_ka": 0.47,
+          "type": "ol",
+          "q_mm2": 149,
+          "alpha": 0.00403
+        },
+        "184-AL1/30-ST1A 20.0": {
+          "c_nf_per_km": 10.75,
+          "r_ohm_per_km": 0.1571,
+          "x_ohm_per_km": 0.33,
+          "max_i_ka": 0.535,
+          "type": "ol",
+          "q_mm2": 184,
+          "alpha": 0.00403
+        },
+        "243-AL1/39-ST1A 20.0": {
+          "c_nf_per_km": 11,
+          "r_ohm_per_km": 0.1188,
+          "x_ohm_per_km": 0.32,
+          "max_i_ka": 0.645,
+          "type": "ol",
+          "q_mm2": 243,
+          "alpha": 0.00403
+        },
+        "48-AL1/8-ST1A 110.0": {
+          "c_nf_per_km": 8,
+          "r_ohm_per_km": 0.5939,
+          "x_ohm_per_km": 0.46,
+          "max_i_ka": 0.21,
+          "type": "ol",
+          "q_mm2": 48,
+          "alpha": 0.00403
+        },
+        "70-AL1/11-ST1A 110.0": {
+          "c_nf_per_km": 8.4,
+          "r_ohm_per_km": 0.4132,
+          "x_ohm_per_km": 0.45,
+          "max_i_ka": 0.29,
+          "type": "ol",
+          "q_mm2": 70,
+          "alpha": 0.00403
+        },
+        "94-AL1/15-ST1A 110.0": {
+          "c_nf_per_km": 8.65,
+          "r_ohm_per_km": 0.306,
+          "x_ohm_per_km": 0.44,
+          "max_i_ka": 0.35,
+          "type": "ol",
+          "q_mm2": 94,
+          "alpha": 0.00403
+        },
+        "122-AL1/20-ST1A 110.0": {
+          "c_nf_per_km": 8.5,
+          "r_ohm_per_km": 0.2376,
+          "x_ohm_per_km": 0.43,
+          "max_i_ka": 0.41,
+          "type": "ol",
+          "q_mm2": 122,
+          "alpha": 0.00403
+        },
+        "149-AL1/24-ST1A 110.0": {
+          "c_nf_per_km": 8.75,
+          "r_ohm_per_km": 0.194,
+          "x_ohm_per_km": 0.41,
+          "max_i_ka": 0.47,
+          "type": "ol",
+          "q_mm2": 149,
+          "alpha": 0.00403
+        },
+        "184-AL1/30-ST1A 110.0": {
+          "c_nf_per_km": 8.8,
+          "r_ohm_per_km": 0.1571,
+          "x_ohm_per_km": 0.4,
+          "max_i_ka": 0.535,
+          "type": "ol",
+          "q_mm2": 184,
+          "alpha": 0.00403
+        },
+        "243-AL1/39-ST1A 110.0": {
+          "c_nf_per_km": 9,
+          "r_ohm_per_km": 0.1188,
+          "x_ohm_per_km": 0.39,
+          "max_i_ka": 0.645,
+          "type": "ol",
+          "q_mm2": 243,
+          "alpha": 0.00403
+        },
+        "305-AL1/39-ST1A 110.0": {
+          "c_nf_per_km": 9.2,
+          "r_ohm_per_km": 0.0949,
+          "x_ohm_per_km": 0.38,
+          "max_i_ka": 0.74,
+          "type": "ol",
+          "q_mm2": 305,
+          "alpha": 0.00403
+        },
+        "490-AL1/64-ST1A 110.0": {
+          "c_nf_per_km": 9.75,
+          "r_ohm_per_km": 0.059,
+          "x_ohm_per_km": 0.37,
+          "max_i_ka": 0.96,
+          "type": "ol",
+          "q_mm2": 490,
+          "alpha": 0.00403
+        },
+        "679-AL1/86-ST1A 110.0": {
+          "c_nf_per_km": 9.95,
+          "r_ohm_per_km": 0.042,
+          "x_ohm_per_km": 0.36,
+          "max_i_ka": 1.15,
+          "type": "ol",
+          "q_mm2": 679,
+          "alpha": 0.00403
+        },
+        "490-AL1/64-ST1A 220.0": {
+          "c_nf_per_km": 10,
+          "r_ohm_per_km": 0.059,
+          "x_ohm_per_km": 0.285,
+          "max_i_ka": 0.96,
+          "type": "ol",
+          "q_mm2": 490,
+          "alpha": 0.00403
+        },
+        "679-AL1/86-ST1A 220.0": {
+          "c_nf_per_km": 11.7,
+          "r_ohm_per_km": 0.042,
+          "x_ohm_per_km": 0.275,
+          "max_i_ka": 1.15,
+          "type": "ol",
+          "q_mm2": 679,
+          "alpha": 0.00403
+        },
+        "490-AL1/64-ST1A 380.0": {
+          "c_nf_per_km": 11,
+          "r_ohm_per_km": 0.059,
+          "x_ohm_per_km": 0.253,
+          "max_i_ka": 0.96,
+          "type": "ol",
+          "q_mm2": 490,
+          "alpha": 0.00403
+        },
+        "679-AL1/86-ST1A 380.0": {
+          "c_nf_per_km": 14.6,
+          "r_ohm_per_km": 0.042,
+          "x_ohm_per_km": 0.25,
+          "max_i_ka": 1.15,
+          "type": "ol",
+          "q_mm2": 679,
+          "alpha": 0.00403
+        }
+      },
+      "trafo": {
+        "160 MVA 380/110 kV": {
+          "i0_percent": 0.06,
+          "pfe_kw": 60,
+          "vkr_percent": 0.25,
+          "sn_mva": 160,
+          "vn_lv_kv": 110.0,
+          "vn_hv_kv": 380.0,
+          "vk_percent": 12.2,
+          "shift_degree": 0,
+          "vector_group": "Yy0",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "100 MVA 220/110 kV": {
+          "i0_percent": 0.06,
+          "pfe_kw": 55,
+          "vkr_percent": 0.26,
+          "sn_mva": 100,
+          "vn_lv_kv": 110.0,
+          "vn_hv_kv": 220.0,
+          "vk_percent": 12.0,
+          "shift_degree": 0,
+          "vector_group": "Yy0",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "63 MVA 110/20 kV": {
+          "i0_percent": 0.04,
+          "pfe_kw": 22,
+          "vkr_percent": 0.32,
+          "sn_mva": 63,
+          "vn_lv_kv": 20.0,
+          "vn_hv_kv": 110.0,
+          "vk_percent": 18,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "40 MVA 110/20 kV": {
+          "i0_percent": 0.05,
+          "pfe_kw": 18,
+          "vkr_percent": 0.34,
+          "sn_mva": 40,
+          "vn_lv_kv": 20.0,
+          "vn_hv_kv": 110.0,
+          "vk_percent": 16.2,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "25 MVA 110/20 kV": {
+          "i0_percent": 0.07,
+          "pfe_kw": 14,
+          "vkr_percent": 0.41,
+          "sn_mva": 25,
+          "vn_lv_kv": 20.0,
+          "vn_hv_kv": 110.0,
+          "vk_percent": 12,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "63 MVA 110/10 kV": {
+          "sn_mva": 63,
+          "vn_hv_kv": 110,
+          "vn_lv_kv": 10,
+          "vk_percent": 18,
+          "vkr_percent": 0.32,
+          "pfe_kw": 22,
+          "i0_percent": 0.04,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "40 MVA 110/10 kV": {
+          "sn_mva": 40,
+          "vn_hv_kv": 110,
+          "vn_lv_kv": 10,
+          "vk_percent": 16.2,
+          "vkr_percent": 0.34,
+          "pfe_kw": 18,
+          "i0_percent": 0.05,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "25 MVA 110/10 kV": {
+          "sn_mva": 25,
+          "vn_hv_kv": 110,
+          "vn_lv_kv": 10,
+          "vk_percent": 12,
+          "vkr_percent": 0.41,
+          "pfe_kw": 14,
+          "i0_percent": 0.07,
+          "shift_degree": 150,
+          "vector_group": "YNd5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -9,
+          "tap_max": 9,
+          "tap_step_degree": 0,
+          "tap_step_percent": 1.5,
+          "tap_phase_shifter": false
+        },
+        "0.25 MVA 20/0.4 kV": {
+          "sn_mva": 0.25,
+          "vn_hv_kv": 20,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 6,
+          "vkr_percent": 1.44,
+          "pfe_kw": 0.8,
+          "i0_percent": 0.32,
+          "shift_degree": 150,
+          "vector_group": "Yzn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        },
+        "0.4 MVA 20/0.4 kV": {
+          "sn_mva": 0.4,
+          "vn_hv_kv": 20,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 6,
+          "vkr_percent": 1.425,
+          "pfe_kw": 1.35,
+          "i0_percent": 0.3375,
+          "shift_degree": 150,
+          "vector_group": "Dyn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        },
+        "0.63 MVA 20/0.4 kV": {
+          "sn_mva": 0.63,
+          "vn_hv_kv": 20,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 6,
+          "vkr_percent": 1.206,
+          "pfe_kw": 1.65,
+          "i0_percent": 0.2619,
+          "shift_degree": 150,
+          "vector_group": "Dyn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        },
+        "0.25 MVA 10/0.4 kV": {
+          "sn_mva": 0.25,
+          "vn_hv_kv": 10,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 4,
+          "vkr_percent": 1.2,
+          "pfe_kw": 0.6,
+          "i0_percent": 0.24,
+          "shift_degree": 150,
+          "vector_group": "Dyn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        },
+        "0.4 MVA 10/0.4 kV": {
+          "sn_mva": 0.4,
+          "vn_hv_kv": 10,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 4,
+          "vkr_percent": 1.325,
+          "pfe_kw": 0.95,
+          "i0_percent": 0.2375,
+          "shift_degree": 150,
+          "vector_group": "Dyn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        },
+        "0.63 MVA 10/0.4 kV": {
+          "sn_mva": 0.63,
+          "vn_hv_kv": 10,
+          "vn_lv_kv": 0.4,
+          "vk_percent": 4,
+          "vkr_percent": 1.0794,
+          "pfe_kw": 1.18,
+          "i0_percent": 0.1873,
+          "shift_degree": 150,
+          "vector_group": "Dyn5",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -2,
+          "tap_max": 2,
+          "tap_step_degree": 0,
+          "tap_step_percent": 2.5,
+          "tap_phase_shifter": false
+        }
+      },
+      "trafo3w": {
+        "63/25/38 MVA 110/20/10 kV": {
+          "sn_hv_mva": 63,
+          "sn_mv_mva": 25,
+          "sn_lv_mva": 38,
+          "vn_hv_kv": 110,
+          "vn_mv_kv": 20,
+          "vn_lv_kv": 10,
+          "vk_hv_percent": 10.4,
+          "vk_mv_percent": 10.4,
+          "vk_lv_percent": 10.4,
+          "vkr_hv_percent": 0.28,
+          "vkr_mv_percent": 0.32,
+          "vkr_lv_percent": 0.35,
+          "pfe_kw": 35,
+          "i0_percent": 0.89,
+          "shift_mv_degree": 0,
+          "shift_lv_degree": 0,
+          "vector_group": "YN0yn0yn0",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -10,
+          "tap_max": 10,
+          "tap_step_percent": 1.2
+        },
+        "63/25/38 MVA 110/10/10 kV": {
+          "sn_hv_mva": 63,
+          "sn_mv_mva": 25,
+          "sn_lv_mva": 38,
+          "vn_hv_kv": 110,
+          "vn_mv_kv": 10,
+          "vn_lv_kv": 10,
+          "vk_hv_percent": 10.4,
+          "vk_mv_percent": 10.4,
+          "vk_lv_percent": 10.4,
+          "vkr_hv_percent": 0.28,
+          "vkr_mv_percent": 0.32,
+          "vkr_lv_percent": 0.35,
+          "pfe_kw": 35,
+          "i0_percent": 0.89,
+          "shift_mv_degree": 0,
+          "shift_lv_degree": 0,
+          "vector_group": "YN0yn0yn0",
+          "tap_side": "hv",
+          "tap_neutral": 0,
+          "tap_min": -10,
+          "tap_max": 10,
+          "tap_step_percent": 1.2
+        }
+      }
+    },
+    "res_bus": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"vm_pu\",\"va_degree\",\"p_mw\",\"q_mvar\"],\"index\":[0,1,2],\"data\":[[1.0,0.0,-33.54823352375729,-43.220067977905273],[0.965426835729015,-1.553797116151071,100.0,100.0],[1.0,0.081329690615668,-67.096467047514537,-63.226937651634216]]}",
+      "orient": "split",
+      "dtype": {
+        "vm_pu": "float64",
+        "va_degree": "float64",
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_line": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_from_mw\",\"q_from_mvar\",\"p_to_mw\",\"q_to_mvar\",\"pl_mw\",\"ql_mvar\",\"i_from_ka\",\"i_to_ka\",\"i_ka\",\"vm_from_pu\",\"va_from_degree\",\"vm_to_pu\",\"va_to_degree\",\"loading_percent\"],\"index\":[0,1,2],\"data\":[[39.169499501294794,42.653911504699181,-38.917979061957347,-40.138707111324706,0.251520439337448,2.515204393374475,1.671727115349234,1.671727115349234,1.671727115349234,1.0,0.0,0.965426835729015,-1.553797116151071,167.172711534923366],[-61.08202093804266,-59.861292888675479,61.474403090870801,63.785114416957057,0.392382152828141,3.923821528281579,2.557284213210564,2.557284213210564,2.557284213210564,0.965426835729015,-1.553797116151071,1.0,0.081329690615668,255.72842132105643],[5.622063956643728,-0.558176601177699,-5.621265977537462,0.566156392240373,0.000797979106267,0.007979791062674,0.163092929160788,0.163092929160788,0.163092929160788,1.0,0.081329690615668,1.0,0.0,16.309292916078768]]}",
+      "orient": "split",
+      "dtype": {
+        "p_from_mw": "float64",
+        "q_from_mvar": "float64",
+        "p_to_mw": "float64",
+        "q_to_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64",
+        "i_ka": "float64",
+        "vm_from_pu": "float64",
+        "va_from_degree": "float64",
+        "vm_to_pu": "float64",
+        "va_to_degree": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_trafo": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_hv_mw\",\"q_hv_mvar\",\"p_lv_mw\",\"q_lv_mvar\",\"pl_mw\",\"ql_mvar\",\"i_hv_ka\",\"i_lv_ka\",\"vm_hv_pu\",\"va_hv_degree\",\"vm_lv_pu\",\"va_lv_degree\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_hv_mw": "float64",
+        "q_hv_mvar": "float64",
+        "p_lv_mw": "float64",
+        "q_lv_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_hv_ka": "float64",
+        "i_lv_ka": "float64",
+        "vm_hv_pu": "float64",
+        "va_hv_degree": "float64",
+        "vm_lv_pu": "float64",
+        "va_lv_degree": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_trafo3w": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_hv_mw\",\"q_hv_mvar\",\"p_mv_mw\",\"q_mv_mvar\",\"p_lv_mw\",\"q_lv_mvar\",\"pl_mw\",\"ql_mvar\",\"i_hv_ka\",\"i_mv_ka\",\"i_lv_ka\",\"vm_hv_pu\",\"va_hv_degree\",\"vm_mv_pu\",\"va_mv_degree\",\"vm_lv_pu\",\"va_lv_degree\",\"va_internal_degree\",\"vm_internal_pu\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_hv_mw": "float64",
+        "q_hv_mvar": "float64",
+        "p_mv_mw": "float64",
+        "q_mv_mvar": "float64",
+        "p_lv_mw": "float64",
+        "q_lv_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_hv_ka": "float64",
+        "i_mv_ka": "float64",
+        "i_lv_ka": "float64",
+        "vm_hv_pu": "float64",
+        "va_hv_degree": "float64",
+        "vm_mv_pu": "float64",
+        "va_mv_degree": "float64",
+        "vm_lv_pu": "float64",
+        "va_lv_degree": "float64",
+        "va_internal_degree": "float64",
+        "vm_internal_pu": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_impedance": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_from_mw\",\"q_from_mvar\",\"p_to_mw\",\"q_to_mvar\",\"pl_mw\",\"ql_mvar\",\"i_from_ka\",\"i_to_ka\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_from_mw": "float64",
+        "q_from_mvar": "float64",
+        "p_to_mw": "float64",
+        "q_to_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64"
+      }
+    },
+    "res_ext_grid": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_load": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[0],\"data\":[[100.0,100.0]]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_motor": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_sgen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_storage": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_shunt": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "vm_pu": "float64"
+      }
+    },
+    "res_gen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\",\"va_degree\",\"vm_pu\"],\"index\":[0,1],\"data\":[[33.54823352375729,43.220067977905273,0.0,1.0],[67.096467047514537,63.226937651634216,0.081329690615668,1.0]]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "va_degree": "float64",
+        "vm_pu": "float64"
+      }
+    },
+    "res_ward": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "vm_pu": "float64"
+      }
+    },
+    "res_xward": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\",\"vm_pu\",\"va_internal_degree\",\"vm_internal_pu\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64",
+        "vm_pu": "float64",
+        "va_internal_degree": "float64",
+        "vm_internal_pu": "float64"
+      }
+    },
+    "res_dcline": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_from_mw\",\"q_from_mvar\",\"p_to_mw\",\"q_to_mvar\",\"pl_mw\",\"vm_from_pu\",\"va_from_degree\",\"vm_to_pu\",\"va_to_degree\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_from_mw": "float64",
+        "q_from_mvar": "float64",
+        "p_to_mw": "float64",
+        "q_to_mvar": "float64",
+        "pl_mw": "float64",
+        "vm_from_pu": "float64",
+        "va_from_degree": "float64",
+        "vm_to_pu": "float64",
+        "va_to_degree": "float64"
+      }
+    },
+    "res_asymmetric_load": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_asymmetric_sgen": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_bus_est": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"vm_pu\",\"va_degree\",\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "vm_pu": "float64",
+        "va_degree": "float64",
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_line_est": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_from_mw\",\"q_from_mvar\",\"p_to_mw\",\"q_to_mvar\",\"pl_mw\",\"ql_mvar\",\"i_from_ka\",\"i_to_ka\",\"i_ka\",\"vm_from_pu\",\"va_from_degree\",\"vm_to_pu\",\"va_to_degree\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_from_mw": "float64",
+        "q_from_mvar": "float64",
+        "p_to_mw": "float64",
+        "q_to_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64",
+        "i_ka": "float64",
+        "vm_from_pu": "float64",
+        "va_from_degree": "float64",
+        "vm_to_pu": "float64",
+        "va_to_degree": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_trafo_est": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_hv_mw\",\"q_hv_mvar\",\"p_lv_mw\",\"q_lv_mvar\",\"pl_mw\",\"ql_mvar\",\"i_hv_ka\",\"i_lv_ka\",\"vm_hv_pu\",\"va_hv_degree\",\"vm_lv_pu\",\"va_lv_degree\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_hv_mw": "float64",
+        "q_hv_mvar": "float64",
+        "p_lv_mw": "float64",
+        "q_lv_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_hv_ka": "float64",
+        "i_lv_ka": "float64",
+        "vm_hv_pu": "float64",
+        "va_hv_degree": "float64",
+        "vm_lv_pu": "float64",
+        "va_lv_degree": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_trafo3w_est": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_hv_mw\",\"q_hv_mvar\",\"p_mv_mw\",\"q_mv_mvar\",\"p_lv_mw\",\"q_lv_mvar\",\"pl_mw\",\"ql_mvar\",\"i_hv_ka\",\"i_mv_ka\",\"i_lv_ka\",\"vm_hv_pu\",\"va_hv_degree\",\"vm_mv_pu\",\"va_mv_degree\",\"vm_lv_pu\",\"va_lv_degree\",\"va_internal_degree\",\"vm_internal_pu\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_hv_mw": "float64",
+        "q_hv_mvar": "float64",
+        "p_mv_mw": "float64",
+        "q_mv_mvar": "float64",
+        "p_lv_mw": "float64",
+        "q_lv_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_hv_ka": "float64",
+        "i_mv_ka": "float64",
+        "i_lv_ka": "float64",
+        "vm_hv_pu": "float64",
+        "va_hv_degree": "float64",
+        "vm_mv_pu": "float64",
+        "va_mv_degree": "float64",
+        "vm_lv_pu": "float64",
+        "va_lv_degree": "float64",
+        "va_internal_degree": "float64",
+        "vm_internal_pu": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_impedance_est": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_from_mw\",\"q_from_mvar\",\"p_to_mw\",\"q_to_mvar\",\"pl_mw\",\"ql_mvar\",\"i_from_ka\",\"i_to_ka\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_from_mw": "float64",
+        "q_from_mvar": "float64",
+        "p_to_mw": "float64",
+        "q_to_mvar": "float64",
+        "pl_mw": "float64",
+        "ql_mvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64"
+      }
+    },
+    "res_bus_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_line_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_trafo_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_trafo3w_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_ext_grid_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_gen_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_sgen_sc": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_bus_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"vm_a_pu\",\"va_a_degree\",\"vm_b_pu\",\"va_b_degree\",\"vm_c_pu\",\"va_c_degree\",\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "vm_a_pu": "float64",
+        "va_a_degree": "float64",
+        "vm_b_pu": "float64",
+        "va_b_degree": "float64",
+        "vm_c_pu": "float64",
+        "va_c_degree": "float64",
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64"
+      }
+    },
+    "res_line_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_a_from_mw\",\"q_a_from_mvar\",\"p_b_from_mw\",\"q_b_from_mvar\",\"q_c_from_mvar\",\"p_a_to_mw\",\"q_a_to_mvar\",\"p_b_to_mw\",\"q_b_to_mvar\",\"p_c_to_mw\",\"q_c_to_mvar\",\"p_a_l_mw\",\"q_a_l_mvar\",\"p_b_l_mw\",\"q_b_l_mvar\",\"p_c_l_mw\",\"q_c_l_mvar\",\"i_a_from_ka\",\"i_a_to_ka\",\"i_b_from_ka\",\"i_b_to_ka\",\"i_c_from_ka\",\"i_c_to_ka\",\"i_a_ka\",\"i_b_ka\",\"i_c_ka\",\"i_n_from_ka\",\"i_n_to_ka\",\"i_n_ka\",\"loading_a_percent\",\"loading_b_percent\",\"loading_c_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_a_from_mw": "float64",
+        "q_a_from_mvar": "float64",
+        "p_b_from_mw": "float64",
+        "q_b_from_mvar": "float64",
+        "q_c_from_mvar": "float64",
+        "p_a_to_mw": "float64",
+        "q_a_to_mvar": "float64",
+        "p_b_to_mw": "float64",
+        "q_b_to_mvar": "float64",
+        "p_c_to_mw": "float64",
+        "q_c_to_mvar": "float64",
+        "p_a_l_mw": "float64",
+        "q_a_l_mvar": "float64",
+        "p_b_l_mw": "float64",
+        "q_b_l_mvar": "float64",
+        "p_c_l_mw": "float64",
+        "q_c_l_mvar": "float64",
+        "i_a_from_ka": "float64",
+        "i_a_to_ka": "float64",
+        "i_b_from_ka": "float64",
+        "i_b_to_ka": "float64",
+        "i_c_from_ka": "float64",
+        "i_c_to_ka": "float64",
+        "i_a_ka": "float64",
+        "i_b_ka": "float64",
+        "i_c_ka": "float64",
+        "i_n_from_ka": "float64",
+        "i_n_to_ka": "float64",
+        "i_n_ka": "float64",
+        "loading_a_percent": "float64",
+        "loading_b_percent": "float64",
+        "loading_c_percent": "float64"
+      }
+    },
+    "res_trafo_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_a_hv_mw\",\"q_a_hv_mvar\",\"p_b_hv_mw\",\"q_b_hv_mvar\",\"p_c_hv_mw\",\"q_c_hv_mvar\",\"p_a_lv_mw\",\"q_a_lv_mvar\",\"p_b_lv_mw\",\"q_b_lv_mvar\",\"p_c_lv_mw\",\"q_c_lv_mvar\",\"p_a_l_mw\",\"q_a_l_mvar\",\"p_b_l_mw\",\"q_b_l_mvar\",\"p_c_l_mw\",\"q_c_l_mvar\",\"i_a_hv_ka\",\"i_a_lv_ka\",\"i_b_hv_ka\",\"i_b_lv_ka\",\"i_c_hv_ka\",\"i_c_lv_ka\",\"loading_a_percent\",\"loading_b_percent\",\"loading_c_percent\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_a_hv_mw": "float64",
+        "q_a_hv_mvar": "float64",
+        "p_b_hv_mw": "float64",
+        "q_b_hv_mvar": "float64",
+        "p_c_hv_mw": "float64",
+        "q_c_hv_mvar": "float64",
+        "p_a_lv_mw": "float64",
+        "q_a_lv_mvar": "float64",
+        "p_b_lv_mw": "float64",
+        "q_b_lv_mvar": "float64",
+        "p_c_lv_mw": "float64",
+        "q_c_lv_mvar": "float64",
+        "p_a_l_mw": "float64",
+        "q_a_l_mvar": "float64",
+        "p_b_l_mw": "float64",
+        "q_b_l_mvar": "float64",
+        "p_c_l_mw": "float64",
+        "q_c_l_mvar": "float64",
+        "i_a_hv_ka": "float64",
+        "i_a_lv_ka": "float64",
+        "i_b_hv_ka": "float64",
+        "i_b_lv_ka": "float64",
+        "i_c_hv_ka": "float64",
+        "i_c_lv_ka": "float64",
+        "loading_a_percent": "float64",
+        "loading_b_percent": "float64",
+        "loading_c_percent": "float64",
+        "loading_percent": "float64"
+      }
+    },
+    "res_ext_grid_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64"
+      }
+    },
+    "res_shunt_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[],\"index\":[],\"data\":[]}",
+      "orient": "split"
+    },
+    "res_load_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_sgen_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_storage_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_mw\",\"q_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_mw": "float64",
+        "q_mvar": "float64"
+      }
+    },
+    "res_asymmetric_load_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64"
+      }
+    },
+    "res_asymmetric_sgen_3ph": {
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{\"columns\":[\"p_a_mw\",\"q_a_mvar\",\"p_b_mw\",\"q_b_mvar\",\"p_c_mw\",\"q_c_mvar\"],\"index\":[],\"data\":[]}",
+      "orient": "split",
+      "dtype": {
+        "p_a_mw": "float64",
+        "q_a_mvar": "float64",
+        "p_b_mw": "float64",
+        "q_b_mvar": "float64",
+        "p_c_mw": "float64",
+        "q_c_mvar": "float64"
+      }
+    },
+    "user_pf_options": {},
+    "OPF_converged": false
+  }
+}

--- a/lightsim2grid/tests/test_Deactivatedbus.py
+++ b/lightsim2grid/tests/test_Deactivatedbus.py
@@ -45,7 +45,10 @@ class MakeACTestsDisco(BaseTests, unittest.TestCase):
     def run_ref_pf(self, net):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.runpp(net, init="flat")
+            pp.runpp(net, init="flat",
+                     lightsim2grid=False,
+                     numba=True, 
+                     distributed_slack=False)
 
     def do_i_skip(self, test_nm):
         return
@@ -75,7 +78,11 @@ class MakeDCTestsDisco(BaseTests, unittest.TestCase):
     def run_ref_pf(self, net):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.rundcpp(net, init="flat")
+            pp.rundcpp(net,
+                       init="flat",
+                       lightsim2grid=False,
+                       numba=True, 
+                       distributed_slack=False)
 
     def do_i_skip(self, test_nm):
         pass

--- a/lightsim2grid/tests/test_GridModel.py
+++ b/lightsim2grid/tests/test_GridModel.py
@@ -23,7 +23,10 @@ class BaseTests:
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.runpp(self.net_datamodel)
+            pp.runpp(self.net_datamodel,
+                     lightsim2grid=False,
+                     numba=True, 
+                     distributed_slack=False)
 
         # initialize constant stuff
         self.max_it = 10
@@ -105,7 +108,11 @@ class BaseTests:
     def run_ref_pf(self, net):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.runpp(net, init="flat")
+            pp.runpp(net,
+                     init="flat",
+                     lightsim2grid=False,
+                     numba=True, 
+                     distributed_slack=False)
 
     def do_i_skip(self, func_name):
         # self.skipTest("dev")
@@ -372,7 +379,11 @@ class MakeDCTests(BaseTests, unittest.TestCase):
     def run_ref_pf(self, net):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.rundcpp(net, init="flat")
+            pp.rundcpp(net,
+                       init="flat",
+                       lightsim2grid=False,
+                       numba=True, 
+                       distributed_slack=False)
 
     def do_i_skip(self, test_nm):
         #self.skipTest("dev")
@@ -400,7 +411,10 @@ class MakeACTests(BaseTests, unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.runpp(net, init="flat")
+            pp.runpp(net, init="flat",
+                     lightsim2grid=False,
+                     numba=True, 
+                     distributed_slack=False)
 
     def do_i_skip(self, test_nm):
         pass

--- a/lightsim2grid/tests/test_NewtonPF.py
+++ b/lightsim2grid/tests/test_NewtonPF.py
@@ -23,7 +23,7 @@ class MakeTests(unittest.TestCase):
         self.max_it = 10
         self.tol = 1e-8  # tolerance for the solver
         self.tol_test = 1e-4  # tolerance for the test (2 matrices are equal if the l_1 of their difference is less than this)
-        self.options = {"max_iteration": self.max_it, "tolerance_mva": self.tol}
+        self.options = {"max_iteration": self.max_it, "tolerance_mva": self.tol, "distributed_slack": True}
         self.ppci = {}
         self.path = None
         self.V_init = None
@@ -56,7 +56,6 @@ class MakeTests(unittest.TestCase):
         try:
             res = self.load_array(myzip, "{}_{}.npy".format(nm, iter_max))
         except:
-            pdb.set_trace()
             raise RuntimeError("{} is not defined for iteration {} for case {}".format(nm, iter_max, self.path))
         return res
 
@@ -66,7 +65,7 @@ class MakeTests(unittest.TestCase):
             V = self._load_vect(myzip, iter_max, "V")
         return J, V
 
-    def compare_sparse_mat(self, J, J_pp, pv, pq):
+    def compare_sparse_mat(self, J, J_pp, pv, pq, dist_slack=True):
         """
         Test that the matrices J and J_pp are almost equal
         :param J:
@@ -76,21 +75,23 @@ class MakeTests(unittest.TestCase):
         :return:
         """
         pvpq = np.r_[pv, pq]
-
-        comp_val = np.abs(J[1:, 1:] - J_pp)  # new in version 0.5.6 : distributed slack added a component to J
+        Jmodif_ls = J[1:, 1:] if dist_slack else J
+        comp_val = np.abs(Jmodif_ls - J_pp)  # new in version 0.5.6 : distributed slack added a component to J
         comp_val = comp_val
         assert np.sum(np.abs(comp_val[:len(pvpq), :len(pvpq)])) <= self.tol_test, "J11 (dS_dVa_r) are not equal"
         assert np.sum(np.abs(comp_val[len(pvpq):, :len(pvpq)])) <= self.tol_test, "J21 (dS_dVa_i) are not equal"
         assert np.sum(np.abs(comp_val[:len(pvpq), len(pvpq):])) <= self.tol_test, "J12 (dS_dVm_r) are not equal"
         assert np.sum(np.abs(comp_val[len(pvpq):, len(pvpq):])) <= self.tol_test, "J22 (dS_dVm_i) are not equal"
 
-    def solver_aux(self):
+    def solver_aux(self, dist_slack=True):
+        if not dist_slack:
+            self.options["distributed_slack"] = False
         V, converged, iterations, J, *_ = newtonpf(self.Ybus, self.Sbus, self.V_init, self.pv, self.pq, self.ppci, self.options)
         assert converged, "the load flow has diverged for {}".format(self.path)
         Va = np.angle(V)
         Vm = np.abs(V)
         J_pp, V_pp = self.load_res(iter_max=iterations)
-        self.compare_sparse_mat(J, J_pp, self.pv, self.pq)
+        self.compare_sparse_mat(J, J_pp, self.pv, self.pq, dist_slack=dist_slack)
         Va_pp = np.angle(V_pp)
         Vm_pp = np.abs(V_pp)
         assert np.sum(np.abs(Va - Va_pp)) <= self.tol_test, "voltages angles are not the same"
@@ -104,6 +105,17 @@ class MakeTests(unittest.TestCase):
                 path_ok = self.load_path(path)
                 if path_ok:
                     self.solver_aux()
+                    nb_tested += 1
+        assert nb_tested == 5, "incorrect number of test cases found, found {} while there should be 5".format(nb_tested)
+
+    def test_dir_single_slack(self):
+        nb_tested = 0
+        for path in os.listdir("."):
+            _, ext = os.path.splitext(path)
+            if ext == ".zip":
+                path_ok = self.load_path(path)
+                if path_ok:
+                    self.solver_aux(dist_slack=False)
                     nb_tested += 1
         assert nb_tested == 5, "incorrect number of test cases found, found {} while there should be 5".format(nb_tested)
 

--- a/lightsim2grid/tests/test_Runner.py
+++ b/lightsim2grid/tests/test_Runner.py
@@ -42,15 +42,29 @@ class TestRunner(TestRunner_glop):
         self.backendClass = LightSimBackend
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.runner = Runner(init_grid_path=self.init_grid_path,
-                                 path_chron=self.path_chron,
-                                 parameters_path=self.parameters_path,
-                                 names_chronics_to_backend=self.names_chronics_to_backend,
-                                 gridStateclass=self.gridStateclass,
-                                 backendClass=self.backendClass,
-                                 rewardClass=L2RPNReward,
-                                 max_iter=self.max_iter,
-                                 name_env="test_runner_env")
+            try:
+                # grid2op <= 1.6.5
+                self.runner = Runner(init_grid_path=self.init_grid_path,
+                                    path_chron=self.path_chron,
+                                    parameters_path=self.parameters_path,
+                                    names_chronics_to_backend=self.names_chronics_to_backend,
+                                    gridStateclass=self.gridStateclass,
+                                    backendClass=self.backendClass,
+                                    rewardClass=L2RPNReward,
+                                    max_iter=self.max_iter,
+                                    name_env="test_runner_env")
+            except TypeError:
+                # grid2op >= 1.6.6
+                self.runner = Runner(init_grid_path=self.init_grid_path,
+                                    path_chron=self.path_chron,
+                                    parameters_path=self.parameters_path,
+                                    names_chronics_to_backend=self.names_chronics_to_backend,
+                                    gridStateclass=self.gridStateclass,
+                                    backendClass=self.backendClass,
+                                    rewardClass=L2RPNReward,
+                                    max_iter=self.max_iter,
+                                    name_env="test_runner_env",
+                                    init_env_path=self.init_grid_path)
 
 
 class TestRunnerFast(TestRunnerFast_glop):

--- a/lightsim2grid/tests/test_SameResPP.py
+++ b/lightsim2grid/tests/test_SameResPP.py
@@ -17,6 +17,7 @@ import scipy
 import warnings
 
 from lightsim2grid import LightSimBackend
+import lightsim2grid
 try:
     from lightsim2grid.solver import KLUSolver
     ClassSolver = KLUSolver
@@ -123,7 +124,7 @@ class MyTestCase(unittest.TestCase):
         # "II - Check for possible solver issues"
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            pp.runpp(backend.init_pp_backend._grid, v_debug=True)
+            pp.runpp(backend.init_pp_backend._grid, v_debug=True, lightsim2grid=False)
         v_tmp = backend.init_pp_backend._grid.res_bus["vm_pu"].values[:nb_sub] + 0j
         v_tmp *= np.exp(1j * np.pi / 180. * backend.init_pp_backend._grid.res_bus["va_degree"].values[:nb_sub])
         v_tmp = np.concatenate((v_tmp, v_tmp))

--- a/lightsim2grid/tests/test_dist_slack_jacobian.py
+++ b/lightsim2grid/tests/test_dist_slack_jacobian.py
@@ -26,11 +26,11 @@ class TestIssueJacobian(unittest.TestCase):
             self.net = pp.from_json("./dist_slack_test.json")
             pp.runpp(self.net, lightsim2grid=False, numba=True, distributed_slack=True)
     
-    def test_jacobian(self):    
+    def test_jacobian_dist_slack(self):    
         """that's the grid described in the issue 
         https://github.com/e2nIEE/pandapower/pull/1455
         """
-        options = {"max_iteration": 10, "tolerance_mva": 1e-8}
+        options = {"max_iteration": 10, "tolerance_mva": 1e-8, "distributed_slack": True}
         V, converged, iterations, J, Vm_it, Va_it = newtonpf_new(self.net._ppc["internal"]["Ybus"], 
                                                                  self.net._ppc["internal"]["Sbus"],
                                                                  np.array([1.+0.j, 1.+0.j, 1.+0.j]),
@@ -41,11 +41,36 @@ class TestIssueJacobian(unittest.TestCase):
                                                                  options)
         assert converged
         assert iterations == 4 
+        assert np.max(np.abs(V - self.net._ppc["internal"]["V"])) <= 1e-6
         if self.net._ppc["internal"]["J"].shape == (4,4):
             # with earlier pandapower version, distributed slack are
             # not taken into account, so this test does not work
             # because pandapower Jacobian has not the same shape.
             assert np.max(np.abs(J - self.net._ppc["internal"]["J"])) <= 1e-6
+    
+    def test_jacobian_single_slack(self):    
+        """that's the grid described in the issue 
+        https://github.com/e2nIEE/pandapower/pull/1455
+        """
+        pp.runpp(self.net, lightsim2grid=False, numba=True, distributed_slack=False)
+        options = {"max_iteration": 10, "tolerance_mva": 1e-8, "distributed_slack": False}
+        V, converged, iterations, J, Vm_it, Va_it = newtonpf_new(self.net._ppc["internal"]["Ybus"], 
+                                                                 self.net._ppc["internal"]["Sbus"],
+                                                                 np.array([1.+0.j, 1.+0.j, 1.+0.j]),
+                                                                 self.net._ppc["internal"]["ref"],
+                                                                 self.net._ppc["internal"]["pv"],
+                                                                 self.net._ppc["internal"]["pq"],
+                                                                 self.net._ppc["internal"],
+                                                                 options)
+        assert converged
+        assert iterations == 4 
+        assert np.max(np.abs(V - self.net._ppc["internal"]["V"])) <= 1e-6
+        if self.net._ppc["internal"]["J"].shape == (3,3):
+            # with earlier pandapower version, distributed slack are
+            # not taken into account, so this test does not work
+            # because pandapower Jacobian has not the same shape.
+            assert np.max(np.abs(J - self.net._ppc["internal"]["J"])) <= 1e-6
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lightsim2grid/tests/test_dist_slack_jacobian.py
+++ b/lightsim2grid/tests/test_dist_slack_jacobian.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+import unittest
+import warnings
+
+import numpy as np
+import pandapower as pp
+from lightsim2grid.newtonpf import newtonpf_new
+import pdb
+
+
+class TestIssueJacobian(unittest.TestCase):
+    """
+    see conversation at https://github.com/e2nIEE/pandapower/pull/1455
+    for a description of the bug
+    """
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            self.net = pp.from_json("./dist_slack_test.json")
+            pp.runpp(self.net, lightsim2grid=False, numba=True, distributed_slack=True)
+    
+    def test_jacobian(self):    
+        """that's the grid described in the issue 
+        https://github.com/e2nIEE/pandapower/pull/1455
+        """
+        options = {"max_iteration": 10, "tolerance_mva": 1e-8}
+        V, converged, iterations, J, Vm_it, Va_it = newtonpf_new(self.net._ppc["internal"]["Ybus"], 
+                                                                 self.net._ppc["internal"]["Sbus"],
+                                                                 np.array([1.+0.j, 1.+0.j, 1.+0.j]),
+                                                                 self.net._ppc["internal"]["ref"],
+                                                                 self.net._ppc["internal"]["pv"],
+                                                                 self.net._ppc["internal"]["pq"],
+                                                                 self.net._ppc["internal"],
+                                                                 options)
+        assert converged
+        assert iterations == 4 
+        if self.net._ppc["internal"]["J"].shape == (4,4):
+            # with earlier pandapower version, distributed slack are
+            # not taken into account, so this test does not work
+            # because pandapower Jacobian has not the same shape.
+            assert np.max(np.abs(J - self.net._ppc["internal"]["J"])) <= 1e-6
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,0 @@
-[build-system]
-requires = [
-    "setuptools>=42",
-    "wheel",
-    "pybind11>=2.4",
-    "numpy"
-]
-build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 import warnings
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 KLU_SOLVER_AVAILABLE = False
 
 # Try to link against SuiteSparse (if available)

--- a/src/BaseNRSolver.tpp
+++ b/src/BaseNRSolver.tpp
@@ -478,26 +478,23 @@ void BaseNRSolver<LinearSolver>::fill_jacobian_matrix_unkown_sparsity_pattern(
 
     // add the slack bus coefficients for the first bus (the "real" slack bus)
     // first row (which corresponds to slack_bus_id)
-    for (Eigen::Index col_id=0; col_id < n_pvpq; ++col_id){
+    const int nb_bus = dS_dVa_r.cols();
+    for (Eigen::Index col_id=0; col_id < nb_bus; ++col_id){
+        const auto J_col = pvpq_inv[col_id];
+        if(J_col < 0) continue;
         for (Eigen::SparseMatrix<real_type>::InnerIterator it(dS_dVa_r, col_id); it; ++it)
         {
-            if(it.row() != slack_bus_id) continue;   // don't add it if it's not the ref slack bus
-            const auto J_col = pvpq_inv[it.col()];
-            if(J_col >= 0){
-                // I need to insert it
-                coeffs.push_back(Eigen::Triplet<double>(0, J_col + 1, it.value()));   // HERE FOR PERF OPTIM (3)
-            }
+            if(it.row() != slack_bus_id) continue;   // don't add it if it's not the ref slack bus          
+            coeffs.push_back(Eigen::Triplet<double>(0, J_col + 1, it.value()));   // HERE FOR PERF OPTIM (3)
         }
     }
-    for (Eigen::Index col_id=0; col_id < n_pq; ++col_id){
+    for (Eigen::Index col_id=0; col_id < nb_bus; ++col_id){
+        const auto J_col = pq_inv[col_id];
+        if(J_col < 0) continue;
         for (Eigen::SparseMatrix<real_type>::InnerIterator it(dS_dVm_r, col_id); it; ++it)
         {
             if(it.row() != slack_bus_id) continue;   // don't add it if it's not the ref slack bus
-            const auto J_col = pq_inv[it.col()];
-            if(J_col >= 0){
-                // I need to insert it
-                coeffs.push_back(Eigen::Triplet<double>(0, static_cast<StorageIndex>(J_col + n_pvpq) + 1, it.value()));   // HERE FOR PERF OPTIM (3)
-            }
+            coeffs.push_back(Eigen::Triplet<double>(0, static_cast<StorageIndex>(J_col + n_pvpq) + 1, it.value()));   // HERE FOR PERF OPTIM (3)
         }
     }
 

--- a/utils/fix_ppnet.py
+++ b/utils/fix_ppnet.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2020-2022, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+
+import pdb
+import pandapower as pp
+import os
+import numpy as np
+import grid2op
+from grid2op.Runner import Runner
+from grid2op.Environment import MultiMixEnvironment, Environment
+from lightsim2grid import LightSimBackend
+from grid2op.MakeEnv.UpdateEnv import _hash_env
+import warnings
+
+
+def fix_pp_net(pp_net):
+    ## sgen
+    if "min_p_mw" in pp_net.sgen:
+        min_p_mw = pp_net.sgen["min_p_mw"].values
+        min_p_mw[~np.isfinite(min_p_mw)] = 0.
+        pp_net.sgen["min_p_mw"][:] = min_p_mw
+
+    if "max_p_mw" in pp_net.sgen:
+        max_p_mw = pp_net.sgen["max_p_mw"].values
+        max_p_mw[~np.isfinite(max_p_mw)] = 0.
+        pp_net.sgen["max_p_mw"][:] = max_p_mw
+
+    if "min_q_mvar" in pp_net.sgen:
+        min_q_mvar = pp_net.sgen["min_q_mvar"].values
+        min_q_mvar[~np.isfinite(min_q_mvar)] = 0.
+        pp_net.sgen["min_q_mvar"][:] = min_q_mvar
+
+    if "max_q_mvar" in pp_net.sgen:
+        max_q_mvar = pp_net.sgen["max_q_mvar"].values
+        max_q_mvar[~np.isfinite(max_q_mvar)] = 0.
+        pp_net.sgen["max_q_mvar"][:] = max_q_mvar
+
+    ## slack bus
+    if np.any(pp_net.gen["slack"].values):
+        # in this case the ext grid is not taken into account, i raise a warning if
+        # there is one
+        slack_bus_ids = pp_net.ext_grid["bus"].values
+        if pp_net.ext_grid.shape[0] >= 1:
+            del pp_net.ext_grid
+        print("INFO: ext_grid deleted because pp_net.gen has some slacks")
+    else:
+        slack_bus_ids = pp_net.ext_grid["bus"].values
+        if pp_net.ext_grid.shape[0] >= 2:
+            raise RuntimeError("We found multiple slack buses in the ext_grid. We cannot modify "
+                               "the grid automatically when this is the case")
+
+        if np.all(np.isin(slack_bus_ids, pp_net.gen["bus"].values)):
+            # all slack buses have a generator connected to them
+            # so i assume it was just a computation artifact, and assign these generators as slack buses
+            slack_gen_ids = np.isin(pp_net.gen["bus"].values, slack_bus_ids)  # id of generators connected to slack bus
+            slack_gen_ids = np.where(slack_gen_ids)[0]  # keep only the id of the generators
+            if "slack_weight" in pp_net.gen:
+                slack_coeff = pp_net.gen["slack_weight"].values[slack_gen_ids]
+            print("INFO: flag \"slack=True\" added in the original grid generators")
+        else:
+            print("INFO: new generators added to serve as slack !")
+            nb_slack = len(slack_bus_ids)
+            if "slack_weight" in pp_net.ext_grid:
+                slack_coeff = 1.0 * pp_net.ext_grid["slack_weight"].values
+            else:
+                slack_coeff = np.ones(nb_slack)
+
+            slack_coeff_norm = slack_coeff / slack_coeff.sum()
+            slack_gen_ids = np.arange(nb_slack) + pp_net.gen.shape[0]
+            slack_contrib = (np.sum(pp_net.gen["p_mw"]) - np.sum(pp_net.load["p_mw"]) ) * slack_coeff_norm
+            nb_init_gen = pp_net.gen.shape[0]
+            for gen_added_id in range(nb_slack):
+                bus_id = slack_bus_ids[gen_added_id]
+                vm_pu = pp_net.ext_grid["vm_pu"].values[gen_added_id]
+                p_mw = slack_contrib[gen_added_id]
+                min_q_mvar = -9999.
+                max_q_mvar = +9999.
+                pp.create_gen(net=pp_net,
+                              name=f"gen_{bus_id}_{gen_added_id+nb_init_gen}",
+                              bus=bus_id,
+                              p_mw=p_mw,
+                              vm_pu=vm_pu,
+                              min_q_mvar=min_q_mvar,
+                              max_q_mvar=max_q_mvar,
+                              slack=True,
+                              )
+                warnings.warn("slack_weight not taken into account !")
+        del pp_net.ext_grid
+
+    ## trafo
+    if pp_net.trafo.shape[0] > 0:
+        tap_neutral = pp_net.trafo["tap_neutral"].values
+        tap_neutral[~np.isfinite(tap_neutral)] = 0.
+        pp_net.trafo["tap_neutral"][:] = tap_neutral
+
+        tap_step_percent = pp_net.trafo["tap_step_percent"].values
+        tap_step_percent[~np.isfinite(tap_step_percent)] = 0.
+        pp_net.trafo["tap_step_percent"][:] = tap_step_percent
+
+        tap_pos = pp_net.trafo["tap_pos"].values
+        tap_pos[~np.isfinite(tap_pos)] = 0.
+        pp_net.trafo["tap_pos"][:] = tap_pos
+
+        shift_degree = pp_net.trafo["shift_degree"].values
+        shift_degree[~np.isfinite(shift_degree)] = 0.
+        pp_net.trafo["shift_degree"][:] = shift_degree
+
+        is_tap_broken = ~np.array([el == "hv" or el == "lv" for el in pp_net.trafo["tap_side"].values])
+        pp_net.trafo["tap_side"][is_tap_broken] = False
+
+        tap_step_degree = pp_net.trafo["tap_step_degree"].values
+        tap_step_degree[~np.isfinite(tap_step_degree)] = 0.
+        pp_net.trafo["tap_step_degree"][:] = tap_step_degree
+
+
+def check_env(env, new_grid_path):
+    # check all warnings are removed
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error")
+        env_nowarn = grid2op.make(env_path,
+                                  grid_path=new_grid_path,
+                                  backend=LightSimBackend(),
+                                  _add_to_name="_no_warn",)
+
+    # basic check to "make sure" I did not mess with the file
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        env_fix = grid2op.make(env_path,
+                               grid_path=new_grid_path,
+                               backend=LightSimBackend(),
+                               _add_to_name="_new",
+                               test=True)
+    assert env_fix._init_grid_path == new_grid_path
+    assert type(env_fix).__name__ != type(env).__name__
+
+    # check the grid is loaded the same way
+    assert env.n_gen == env_fix.n_gen
+    assert len(env.name_gen) == len(env_fix.name_gen)
+    assert np.all(env.name_gen == env_fix.name_gen)
+    dict_ref = env.cls_to_dict()
+    del dict_ref["env_name"]
+    dict_new = env_fix.cls_to_dict()
+    del dict_new["env_name"]
+    assert dict_new == dict_ref
+
+    # check it leads to the same results
+    runner = Runner(**env.get_params_for_runner())
+    runner_fix = Runner(**env_fix.get_params_for_runner())
+
+    nb_episode = 10
+    max_iter = 288*2
+    res = runner.run(nb_episode=nb_episode,
+                     pbar=True,
+                     max_iter=max_iter,
+                     env_seeds=[0] * nb_episode)
+    res_fix = runner_fix.run(nb_episode=nb_episode,
+                             pbar=True,
+                             max_iter=max_iter,
+                             env_seeds=[0] * nb_episode)
+
+    for i, (path_, nm_, cum_reward, nb_step, total_step) in enumerate(res):
+        path_fix, nm_fix, cum_reward_fix, nb_step_fix, total_step_fix = res_fix[i]
+        assert cum_reward == cum_reward_fix, f"{cum_reward_fix = } vs {cum_reward = } for {nm_}"
+        assert nb_step == nb_step_fix, f"{nb_step_fix = } vs {nb_step = }"
+
+
+    assert res == res_fix
+
+
+def fix_for_unit_env(env_path, init_grid_path, env, env_pp):
+    pp_net = pp.from_json(init_grid_path)
+
+    # check that i can perform the tests
+    runner = Runner(**env.get_params_for_runner())
+    runner_pp = Runner(**env_pp.get_params_for_runner())
+    nb_episode = 4
+    max_iter = 100
+    res = runner.run(nb_episode=nb_episode, pbar=True, max_iter=max_iter, env_seeds=[0] * nb_episode)
+    res_pp = runner_pp.run(nb_episode=nb_episode, pbar=True, max_iter=max_iter, env_seeds=[0] * nb_episode)
+    assert res == res_pp, "pandapower and lightsim2grid does not give the same result. Stopping there"
+
+
+    # back it up (if not done already)
+    grid_backup = os.path.join(env_path, "grid.json.save")
+    if not os.path.exists(grid_backup):
+        pp.to_json(pp_net, grid_backup)
+
+    # fix it
+    fix_pp_net(pp_net)
+
+    # check it works
+    new_grid_path = os.path.abspath(f"./{env_name}_grid.json")
+    pp.to_json(pp_net, new_grid_path)
+    check_env(env, new_grid_path)
+
+    # save the new grid
+    pp.to_json(pp_net, init_grid_path)
+    return new_grid_path
+
+
+if __name__ == "__main__":
+    env_name = "rte_case14_redisp"
+    env_name = "l2rpn_case14_sandbox"
+    env_name = "l2rpn_2019"
+    env_name = "rte_case14_realistic"
+    env_name = "l2rpn_wcci_2020"
+    env_name = "l2rpn_neurips_2020_track1_small"
+    env_name = "l2rpn_neurips_2020_track1_large"
+    env_name = "l2rpn_icaps_2021_small"
+    env_name = "l2rpn_icaps_2021_large"
+    env_name = "l2rpn_neurips_2020_track2_small"
+    env_name = "l2rpn_neurips_2020_track2_large"
+
+    # env_name = "l2rpn_neurips_2020_track2_small"
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        env = grid2op.make(env_name, backend=LightSimBackend())
+        env_pp = grid2op.make(env_name)
+
+    env_path = env.get_path_env()
+    final_path = env_path = env.get_path_env()
+    if isinstance(env, MultiMixEnvironment):
+        key = next(iter(env.keys()))
+        super_env = env
+        super_env_pp = env_pp
+        env = super_env[key]
+        env_pp = super_env_pp[key]
+        
+        env_path = env.get_path_env()
+        final_path = super_env.get_path_env()
+    elif not isinstance(env, Environment):
+        raise RuntimeError("Unuspported environment type !")
+    
+    init_grid_path = os.path.join(env_path, "grid.json")
+    new_grid_path = fix_for_unit_env(env_path, init_grid_path, env, env_pp)
+
+    # compute the hash:
+    print(f"hash for {env_name} {_hash_env(final_path).hexdigest()}")
+    print(f"new file for {env_name} {new_grid_path}")

--- a/utils/fix_ppnet.py
+++ b/utils/fix_ppnet.py
@@ -242,5 +242,7 @@ if __name__ == "__main__":
     new_grid_path = fix_for_unit_env(env_path, init_grid_path, env, env_pp)
 
     # compute the hash:
-    print(f"hash for {env_name} {_hash_env(final_path).hexdigest()}")
+    print(f"hash for {env_name} {_hash_env(final_path).hexdigest()} (wrong for multimix... "
+           "for them, upload the files, update this fake hash. Update the env, recompute the hash"
+           " and then reupload the right one.")
     print(f"new file for {env_name} {new_grid_path}")


### PR DESCRIPTION
- [BREAKING] the behaviour of the `newton_pf` function is not 
  consistent with pandapower default concerning distributed slack.
- [FIXED] an issue in the distributed slack case spotted by pandapower team 
  thanks to them (see https://github.com/e2nIEE/pandapower/pull/1455)
- [IMPROVED] lightsim2grid will now use the single slack algorithm if the 
  grids counts only one slack bus (performance increase)