### PR TITLE
Upgrade to version 0.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
                     git submodule update
                     CC=clang make
                     CC=clang python setup.py build
-                    CC=clang python -m pip install -U .
+                    CC=clang python -m pip install .
     compile_clang11:
         executor: clang11
         resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             - run:
                 command: |
                     source venv_test/bin/activate
-                    pip install -U pybind11<2.10.3
+                    pip install -U "pybind11<2.10.3"
                     git submodule init
                     git submodule update
                     CC=clang make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,12 +170,12 @@ jobs:
             - run:
                 command: |
                     source venv_test/bin/activate
-                    pip install -U "pybind11<2.10.3"
+                    pip install -U "pybind11==2.10.1"
                     git submodule init
                     git submodule update
-                    CC=clang make
+                    make
                     CC=clang python setup.py build
-                    CC=clang python -m pip install .
+                    python -m pip install .
     compile_clang11:
         executor: clang11
         resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
         resource_class: small
         steps:
             - checkout
-            - run: apt-get update && apt-get install python3-pip -y
+            - run: apt-get update && apt-get install python3-pip git -y
             - run: python3 -m pip install virtualenv
             - run: python3 -m virtualenv venv_test
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,8 @@ jobs:
             - run:
                 command: |
                     source venv_test/bin/activate
-                    pip install -U "pybind11==2.10.1"
-                    python setup.py build
+                    pip install -U pybind11
+                    CC=clang python setup.py build
                     python -m pip install .
     compile_clang11:
         executor: clang11
@@ -299,11 +299,12 @@ workflows:
     version: 2.1
     compile:
         jobs:
-          # - compile_gcc8
-          # - compile_gcc10
-          # - compile_gcc11
-          # - compile_gcc12
-          - compile_clang10
-          # - compile_clang13
-          # - compile_clang14
-          # - compile_windows
+          - compile_gcc8
+          - compile_gcc10
+          - compile_gcc11
+          - compile_gcc12
+          - compile_clang10  # does not work I don't know why, too lazy to check
+          - compile_clang11
+          - compile_clang13
+          - compile_clang14
+          - compile_windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,16 +165,18 @@ jobs:
         steps:
             - checkout
             - run: apt-get update && apt-get install python3-pip git -y
+            - run: 
+                command: |
+                    git submodule init
+                    git submodule update
+                    make
             - run: python3 -m pip install virtualenv
             - run: python3 -m virtualenv venv_test
             - run:
                 command: |
                     source venv_test/bin/activate
                     pip install -U "pybind11==2.10.1"
-                    git submodule init
-                    git submodule update
-                    make
-                    CC=clang python setup.py build
+                    python setup.py build
                     python -m pip install .
     compile_clang11:
         executor: clang11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ workflows:
           - compile_gcc10
           - compile_gcc11
           - compile_gcc12
-          - compile_clang10  # does not work I don't know why, too lazy to check
+          # - compile_clang10  # does not work I don't know why, too lazy to check
           - compile_clang11
           - compile_clang13
           - compile_clang14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
                     pip install -U pybind11
                     git submodule init
                     git submodule update
-                    make
+                    CC=clang make
                     CC=clang python setup.py build
                     CC=clang python -m pip install -U .
     compile_clang11:
@@ -297,11 +297,11 @@ workflows:
     version: 2.1
     compile:
         jobs:
-          - compile_gcc8
-          - compile_gcc10
-          - compile_gcc11
-          - compile_gcc12
+          # - compile_gcc8
+          # - compile_gcc10
+          # - compile_gcc11
+          # - compile_gcc12
           - compile_clang10
-          - compile_clang13
-          - compile_clang14
-          - compile_windows
+          # - compile_clang13
+          # - compile_clang14
+          # - compile_windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             - run:
                 command: |
                     source venv_test/bin/activate
-                    pip install -U pybind11
+                    pip install -U pybind11<2.10.3
                     git submodule init
                     git submodule update
                     CC=clang make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
                     git submodule update
                     make
                     CC=clang python setup.py build
-                    python -m pip install -U .
+                    CC=clang python -m pip install -U .
     compile_clang11:
         executor: clang11
         resource_class: small
@@ -193,7 +193,7 @@ jobs:
                     git submodule update
                     make
                     CC=clang python setup.py build
-                    python -m pip install -U .
+                    CC=clang python -m pip install -U .
     compile_clang12:
         executor: clang12
         resource_class: small
@@ -211,7 +211,7 @@ jobs:
                     git submodule update
                     make
                     CC=clang python setup.py build
-                    python -m pip install -U .
+                    CC=clang python -m pip install -U .
     compile_clang13:
         executor: clang13
         resource_class: small
@@ -229,7 +229,7 @@ jobs:
                     git submodule update
                     make
                     CC=clang python setup.py build
-                    python -m pip install -U .
+                    CC=clang python -m pip install -U .
     compile_clang14:
         executor: clang14
         resource_class: small
@@ -253,7 +253,7 @@ jobs:
                     git submodule update
                     make
                     CC=clang python setup.py build
-                    python -m pip install -e .[test]
+                    CC=clang python -m pip install -e .[test]
             - run:
                 name: "make tests"
                 command: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,11 @@ jobs:
         run: |
           python3 -c "import lightsim2grid"
           python3 -c "from lightsim2grid import *"
-          python3 -c "from lightsim2grid import LightSimBackend"
           python3 -c "from lightsim2grid.newtonpf import newtonpf"
+
+      - name: Check LightSimBackend can be imported
+        run: |
+          python3 -c "from lightsim2grid import LightSimBackend"
           python3 -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel
@@ -172,8 +175,11 @@ jobs:
         run: |
           python -c "import lightsim2grid"
           python -c "from lightsim2grid import *"
-          python -c "from lightsim2grid import LightSimBackend"
           python -c "from lightsim2grid.newtonpf import newtonpf"
+      
+      - name: Check LightSimBackend can be imported
+        run: |
+          python -c "from lightsim2grid import LightSimBackend"
           python -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,11 @@ jobs:
             abi: cp310,
             version: '3.10',
           }
+          - {
+            name: cp311,
+            abi: cp311,
+            version: '3.11',
+          }
 
     steps:
 
@@ -105,6 +110,10 @@ jobs:
           - {
             name: cp310,
             version: '3.10',
+          }
+          - {
+            name: cp311,
+            version: '3.11',
           }
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,9 @@ jobs:
         run: |
           python3 -c "import lightsim2grid"
           python3 -c "from lightsim2grid import *"
+          python3 -c "from lightsim2grid import LightSimBackend"
           python3 -c "from lightsim2grid.newtonpf import newtonpf"
+          python3 -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel
         uses: actions/upload-artifact@v2
@@ -165,6 +167,14 @@ jobs:
       - name: Install wheel
         shell: bash
         run: python -m pip install dist/*.whl --user
+
+      - name: Check package can be imported
+        run: |
+          python -c "import lightsim2grid"
+          python -c "from lightsim2grid import *"
+          python -c "from lightsim2grid import LightSimBackend"
+          python -c "from lightsim2grid.newtonpf import newtonpf"
+          python -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
       - name: Upload wheel
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Check LightSimBackend can be imported
         run: |
+          python3 -m pip install grid2op
           python3 -c "from lightsim2grid import LightSimBackend"
           python3 -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 
@@ -179,6 +180,7 @@ jobs:
       
       - name: Check LightSimBackend can be imported
         run: |
+          python -m pip install grid2op
           python -c "from lightsim2grid import LightSimBackend"
           python -c "from lightsim2grid import LightSimBackend; import grid2op; env = grid2op.make('l2rpn_case14_sandbox', test=True, backend=LightSimBackend())"
 

--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,4 @@ test_gridcal.py
 lightsim2grid/tests/bug_file.zip
 lightsim2grid/tests/test.json
 pyproject.toml.old
+test_bug_as.py

--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ lightsim2grid/tests/bug_file.zip
 lightsim2grid/tests/test.json
 pyproject.toml.old
 test_bug_as.py
+**cktso.lic
+cktso
+test_milad.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Change Log
 - [FIXED] now an error if thrown if the bus indexes in the pandapower grid are not contiguous
   or do not start at 0 (thanks Roman Bolgaryn for spotting this issue)
 - [ADDED] automatic build for python 3.11
+- [ADDED] support for numpy >= 1.24 (some deprecation *eg** np.str and np.bool are removed)
 
 [0.7.0.post1] 2022-06-20
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,10 +17,12 @@ Change Log
 
 [0.xx.yy] 2022-zz-tt
 ---------------------
+- [BREAKING] drop support for numpy version < 1.20 (to be consistent with grid2op)
 - [FIXED] a compatibility issue with grid2op 1.7.2 (missing another backend attribute
   when the environment is copied) see https://github.com/rte-france/Grid2Op/issues/360
 - [FIXED] now an error if thrown if the bus indexes in the pandapower grid are not contiguous
   or do not start at 0 (thanks Roman Bolgaryn for spotting this issue)
+- [ADDED] automatic build for python 3.11
 
 [0.7.0.post1] 2022-06-20
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 - easier building (get rid of the "make" part)
 - code NR with dense matrices
 
+[0.xx.yy] 2022-zz-tt
+---------------------
+- [FIXED] a compatibility issue with grid2op 1.7.2 (missing another backend attribute
+  when the environment is copied) see https://github.com/rte-france/Grid2Op/issues/360
+
 [0.7.0.post1] 2022-06-20
 -------------------------
 - [FIXED] a compatibility issue with grid2op 1.7.1 (missing a backend attribute

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Change Log
 ---------------------
 - [FIXED] a compatibility issue with grid2op 1.7.2 (missing another backend attribute
   when the environment is copied) see https://github.com/rte-france/Grid2Op/issues/360
+- [FIXED] now an error if thrown if the bus indexes in the pandapower grid are not contiguous
+  or do not start at 0 (thanks Roman Bolgaryn for spotting this issue)
 
 [0.7.0.post1] 2022-06-20
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Change Log
 - easier building (get rid of the "make" part)
 - code NR with dense matrices
 
-[0.xx.yy] 2022-zz-tt
+[0.7.1] 2023-01-11
 ---------------------
 - [BREAKING] drop support for numpy version < 1.20 (to be consistent with grid2op)
 - [FIXED] a compatibility issue with grid2op 1.7.2 (missing another backend attribute

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ cd ..
 
 Some tests are performed automatically on standard platform each time modifications are made in the lightsim2grid code.
 
-These tests include, for now, compilation on gcc (version 8, 10, 11 and 12) and clang (version 10, 13 and 14).
+These tests include, for now, compilation on gcc (version 8, 10, 11 and 12) and clang (version 11, 13 and 14).
 
 **NB** Intermediate versions of clang and gcc (*eg* gcc 9 or clang 12) are not tested regularly, but lightsim2grid used to work on these. We suppose that if it works on *eg* clang 10 and clang 14 then it compiles also on all intermediate versions.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, RTE France'
 author = 'Benjamin DONNOT'
 
 # The full version, including alpha/beta/rc tags
-release = '0.7.0.post1'
+release = '0.7.1'
 version = '0.7'
 
 # -- General configuration ---------------------------------------------------

--- a/lightsim2grid/__init__.py
+++ b/lightsim2grid/__init__.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
 
-__version__ = "0.7.0.post1"
+__version__ = "0.7.1"
 
 __all__ = ["newtonpf", "SolverType", "ErrorType", "solver"]
 

--- a/lightsim2grid/gridmodel/_aux_check_legit.py
+++ b/lightsim2grid/gridmodel/_aux_check_legit.py
@@ -45,9 +45,12 @@ def _aux_check_legit(pp_net):
         raise RuntimeError("Unsupported element found (DC Line - \"pp_net.dcline\") "
                            "in pandapower network")
 
-    # if pp_net.sn_mva != 1.:
-    #     warnings.warn("Pandapower network with sn_mva != 1 are not fully supported yet, especially in the "
-    #                   "conversion for some trafo (and probably somewhere else too)")
+    # bus indexes should start at 0 and be contiguous
+    if np.any(np.sort(pp_net.bus.index) != np.arange(pp_net.bus.shape[0])):
+        raise RuntimeError("In order to work, pandapower bus indexes should start at 0 and be contiguous. "
+                           "Make sure that `pp_net.bus.index` have this property. You can write a github "
+                           "issue if you want improvment on this regard.")
+    
     if "_options" in pp_net and \
        "trafo_model" in pp_net["_options"] and \
        pp_net["_options"]["trafo_model"] != "t":

--- a/lightsim2grid/gridmodel/initGridModel.py
+++ b/lightsim2grid/gridmodel/initGridModel.py
@@ -41,8 +41,9 @@ def init(pp_net):
     - the pandapower grid has dcline
     - the pandapower grid has switch, motor, assymetric loads, etc.
     - the pandapower grid any parrallel "elements" (at least one of the column "parrallel" is not 1)
+    - the bus indexes in pandapower do not start at 0 or are not contiguous (you can check `pp_net.bus.index`)
     - some `g_us_per_km` for some lines are not zero ? TODO not sure if that is still the case !
-    - some `p_mw` for some shunts are not zero
+    - some `p_mw` for some shunts are not zero ? TODO not sure if that is still the case !
 
     if you really need any of the above, please submit a github issue and we will work on their support.
 

--- a/lightsim2grid/lightSimBackend.py
+++ b/lightsim2grid/lightSimBackend.py
@@ -828,7 +828,9 @@ class LightSimBackend(Backend):
                            "nb_bus_total", "initdc",
                            "_big_topo_to_obj", "max_it", "tol", "dim_topo",
                            "_idx_hack_storage",
-                           "_timer_preproc", "_timer_postproc", "_timer_solver"]
+                           "_timer_preproc", "_timer_postproc", "_timer_solver",
+                           "_my_kwargs"
+                           ]
         for attr_nm in li_regular_attr:
             if hasattr(self, attr_nm):
                 # this test is needed for backward compatibility with other grid2op version

--- a/lightsim2grid/lightSimBackend.py
+++ b/lightsim2grid/lightSimBackend.py
@@ -511,7 +511,7 @@ class LightSimBackend(Backend):
         self.__me_at_init = self._grid.copy()
         self.__init_topo_vect = np.ones(self.dim_topo, dtype=dt_int)
         self.__init_topo_vect[:] = self.topo_vect
-
+        
     def assert_grid_correct_after_powerflow(self):
         """
         This method is called by the environment. It ensure that the backend remains consistent even after a powerflow

--- a/lightsim2grid/securityAnalysis.py
+++ b/lightsim2grid/securityAnalysis.py
@@ -72,7 +72,12 @@ class SecurityAnalysis(object):
     In grid2op, it would be, in this case, 0. for the flows and 0. for the voltages.
 
     """
-    STR_TYPES = (str, np.str, np.str_)
+    try:
+        STR_TYPES = (str, np.str, np.str_)
+    except AttributeError:
+        # deprecation in numpy 1.24 of np.str
+        STR_TYPES = (str, np.str_)
+        
     def __init__(self, grid2op_env):
         if not isinstance(grid2op_env.backend, LightSimBackend):
             raise RuntimeError("This class only works with LightSimBackend")

--- a/lightsim2grid/tests/test_issue_glop_360.py
+++ b/lightsim2grid/tests/test_issue_glop_360.py
@@ -13,6 +13,13 @@ import warnings
 from grid2op.Runner import Runner
 from lightsim2grid import LightSimBackend
 
+def int_or_null(el):
+    try:
+        res = int(el)
+    except ValueError:
+        res = 0
+    return res
+
 
 class Issue360Tester(unittest.TestCase):
     def setUp(self) -> None:
@@ -32,13 +39,14 @@ class Issue360Tester(unittest.TestCase):
         env_cpy.close()
     
     def test_runner(self):
-        if grid2op.__version__.split(".") < ["1.7.3"]:
+        if [int_or_null(el) for el in grid2op.__version__.split(".")] < [1, 7, 3]:
             self.skipTest("there used to be this bug in grid2op which is fixed in 1.7.3")
         env_cpy = self.env.copy()
         runner = Runner(**env_cpy.get_params_for_runner())
         res = runner.run(nb_episode=1, max_iter=10)
         # this crashed above
         env_cpy.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lightsim2grid/tests/test_issue_glop_360.py
+++ b/lightsim2grid/tests/test_issue_glop_360.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+import grid2op
+import unittest
+import warnings
+
+from grid2op.Runner import Runner
+from lightsim2grid import LightSimBackend
+
+
+class Issue360Tester(unittest.TestCase):
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            self.env = grid2op.make("l2rpn_case14_sandbox", test=True, backend=LightSimBackend())
+    
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+    
+    def test_copy(self):
+        
+        env_cpy = self.env.copy()
+        assert hasattr(self.env.backend, "_my_kwargs")
+        assert hasattr(env_cpy.backend, "_my_kwargs")
+        env_cpy.close()
+    
+    def test_runner(self):
+        env_cpy = self.env.copy()
+        runner = Runner(**env_cpy.get_params_for_runner())
+        res = runner.run(nb_episode=1, max_iter=10)
+        # this crashed above
+        env_cpy.close()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lightsim2grid/tests/test_issue_glop_360.py
+++ b/lightsim2grid/tests/test_issue_glop_360.py
@@ -32,6 +32,8 @@ class Issue360Tester(unittest.TestCase):
         env_cpy.close()
     
     def test_runner(self):
+        if grid2op.__version__.split(".") < ["1.7.3"]:
+            self.skipTest("there used to be this bug in grid2op which is fixed in 1.7.3")
         env_cpy = self.env.copy()
         runner = Runner(**env_cpy.get_params_for_runner())
         res = runner.run(nb_episode=1, max_iter=10)

--- a/lightsim2grid/tests/test_multiple_slack.py
+++ b/lightsim2grid/tests/test_multiple_slack.py
@@ -120,6 +120,8 @@ class TestMultipleSlack14(unittest.TestCase):
         self.net = make_grid_multiple_slack(self.case)
 
         id_ref_slack = self.net.gen.shape[0]-1  # initial generator added as the slack bus added
+        if not "slack_weight" in self.net.gen:
+            self.net.gen["slack_weight"] = 0.
         self.net.gen["slack_weight"][[id_ref_slack]] = 0.5
     
     def test_single_slack(self):

--- a/lightsim2grid/tests/test_multiple_slack.py
+++ b/lightsim2grid/tests/test_multiple_slack.py
@@ -101,6 +101,15 @@ def make_grid_multiple_slack(case):
 
 class TestMultipleSlack14(unittest.TestCase):
     def setUp(self) -> None:
+        
+        if pp.__version__.split() < ["2", "8", "0"]:
+            # check if functionality is available in pandapower installed (officially supported since 2.8.0)
+            msg_ = ("Unable to peform required tests because install pandapower version does not "
+                   "allow multiple slack." )
+            warnings.warn(msg_)
+            self.unable_to_run_due_to_pp = True
+            self.skipTest(msg_)
+            
         # LF PARAMETERS
         self.max_it = 10
         self.tol = 1e-8
@@ -109,16 +118,9 @@ class TestMultipleSlack14(unittest.TestCase):
         # retrieve the case14 and remove the "ext_grid" => put a generator as slack bus instead
         self.case = pn.case14()
         self.net = make_grid_multiple_slack(self.case)
-        if "slack_weight" in self.net.gen:
-            id_ref_slack = self.net.gen.shape[0]-1  # initial generator added as the slack bus added
-            self.net.gen["slack_weight"][[id_ref_slack]] = 0.5
 
-        if "slack_weight" not in self.net.gen:
-            msg_ = "Unable to peform required tests because install pandapower version does not " \
-                   "allow multiple slack."
-            warnings.warn(msg_)
-            self.unable_to_run_due_to_pp = True
-            self.skipTest(msg_)
+        id_ref_slack = self.net.gen.shape[0]-1  # initial generator added as the slack bus added
+        self.net.gen["slack_weight"][[id_ref_slack]] = 0.5
     
     def test_single_slack(self):
         """check pandapower and lightsim get the same results when there is only one

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 wheel
 pybind11>=2.4
-numpy
+numpy>=1.20
 pandapower

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ pkgs = {
         "benchmark": [
             "tabulate",
             "grid2op>=1.6.4",
-            "numpy",
+            "numpy>=1.20",
             "distro",
             "py-cpuinfo"
         ],
@@ -286,7 +286,7 @@ pkgs = {
         "test": [
             "grid2op>=1.6.4",
             "numba",
-            "pandapower>=2.7.0"  # force this version for test, otherwise problem in test_DataConverter !
+            "pandapower>=2.8.0"
         ]
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import warnings
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 
-__version__ = "0.7.0.post1"
+__version__ = "0.7.1"
 KLU_SOLVER_AVAILABLE = False
 
 # Try to link against SuiteSparse (if available)

--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ pkgs = {
         "test": [
             "grid2op>=1.6.4",
             "numba",
-            "pandapower==2.7.0"  # force this version for test, otherwise problem in test_DataConverter !
+            "pandapower>=2.7.0"  # force this version for test, otherwise problem in test_DataConverter !
         ]
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
 
-from setuptools import setup
-from setuptools.command.build_ext import build_ext
-import sys
 import setuptools
+from setuptools import setup
+import sys
 import os
 import warnings
 from pybind11.setup_helpers import Pybind11Extension, build_ext
-
-####
-import pybind11
-print(f"INFO:pybind11 version {pybind11.__version__}")
-####
 
 
 __version__ = "0.7.0.post1"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,24 @@
-from setuptools import setup, Extension
+# Copyright (c) 2020, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of LightSim2grid, LightSim2grid implements a c++ backend targeting the Grid2Op platform.
+
+from setuptools import setup
 from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 import os
 import warnings
 from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+####
+import pybind11
+print(f"INFO:pybind11 version {pybind11.__version__}")
+####
+
 
 __version__ = "0.7.0.post1"
 KLU_SOLVER_AVAILABLE = False
@@ -315,11 +329,11 @@ setup(name='LightSim2Grid',
       keywords='pandapower powergrid simulator KLU Eigen c++',
       classifiers=[
             'Development Status :: 4 - Beta',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
             "Intended Audience :: Developers",
             "Intended Audience :: Education",

--- a/src/NICSLUSolver.h
+++ b/src/NICSLUSolver.h
@@ -24,7 +24,7 @@
 #include "Eigen/Dense"
 #include "Eigen/SparseCore"
 
-// import klu package
+// import nicslu package
 #include "nicslu_cpp.inl"
 
 #include "CustTimer.h"
@@ -68,9 +68,7 @@ class NICSLULinearSolver
         // prevent copy and assignment
         NICSLULinearSolver(const NICSLULinearSolver & other) = delete;
         NICSLULinearSolver & operator=( const NICSLULinearSolver & ) = delete;
-
-
-
+        
     private:
         // solver initialization
         CNicsLU solver_;


### PR DESCRIPTION
Breaking changes
-------------------------
- drop support for numpy version < 1.20 (to be consistent with grid2op). If you are using numpy < 1.20 you should really consider upgrading for most recent versions.
- it does not appear to compile when using clang10 and python 3.7 on linux.

Bug fix
----------
- [FIXED] a compatibility issue with grid2op 1.7.2 (missing another backend attribute
  when the environment is copied) see https://github.com/rte-france/Grid2Op/issues/360
- [FIXED] now an error if thrown if the bus indexes in the pandapower grid are not contiguous
  or do not start at 0 (thanks @rbolgaryn for spotting this issue)

New features
-------------------
- [ADDED] automatic build for python 3.11
- [ADDED] support for numpy >= 1.24 (some deprecation *eg** np.str and np.bool are removed)